### PR TITLE
Cleaner level abbreviation

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -25,6 +25,12 @@ git-tree-sha1 = "1833bda4a027f4b2a1c984baddcf755d77266818"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 version = "1.1.0"
 
+[[Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "5856d3031cdb1f3b2b6340dfdc66b6d9a149a374"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.2.0"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Willow Ahrens"]
 version = "0.1.0"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -15,13 +16,14 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SyntaxInterface = "b33eeca9-aacb-4496-a840-e75f1646a4fb"
 
 [compat]
-RewriteTools = "0.1"
-MacroTools = "0.5"
-Revise = "3"
-SyntaxInterface = "0.1"
-Requires = "1"
-SnoopPrecompile = "1"
 julia = "1.6.7"
+Compat = "3.29"
+MacroTools = "0.5"
+Requires = "1"
+Revise = "3"
+RewriteTools = "0.1"
+SnoopPrecompile = "1"
+SyntaxInterface = "0.1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Finch.jl
+++ b/src/Finch.jl
@@ -9,6 +9,7 @@ using Base.Iterators
 using Base: @kwdef
 using SparseArrays
 using SnoopPrecompile
+using Compat
 
 export @finch, @finch_program, @finch_code, value
 

--- a/src/fibers.jl
+++ b/src/fibers.jl
@@ -233,12 +233,11 @@ end
 """
     @fiber ctr
 
-Construct a fiber using abbreviated level constructor names. Variable names that
-correspond to abbreviations will be substituted with corresponding level constructors,
-otherwise they have normal scoping rules. Expressions may be interpolated with `\$`.
-`Fiber(DenseLevel(SparseListLevel(Element(0.0))))` can also be constructed
-as `@fiber(sl(d(e(0.0))))`. Consult the documentation for the helper function
-[f_code](@ref) for a full listing of format codes.
+Construct a fiber using abbreviated level constructor names. To override
+abbreviations, expressions may be interpolated with `\$`. For example,
+`Fiber(DenseLevel(SparseListLevel(Element(0.0))))` can also be constructed as
+`@fiber(sl(d(e(0.0))))`. Consult the documentation for the helper function
+[f_code](@ref) for a full listing of level format codes.
 """
 macro fiber(ex)
     function walk(ex)

--- a/src/scalars.jl
+++ b/src/scalars.jl
@@ -2,6 +2,7 @@ mutable struct Scalar{D, Tv}# <: AbstractArray{Tv, 0}
     val::Tv
 end
 
+Scalar(D, args...) = Scalar{D}(args...)
 Scalar{D}(args...) where {D} = Scalar{D, typeof(D)}(args...)
 Scalar{D, Tv}() where {D, Tv} = Scalar{D, Tv}(D)
 


### PR DESCRIPTION
The @fiber macro now just overrides each symbol, leaving room for normal scoping rules if it's not an abbreviation.