### PR TITLE
Small fix to allow finch_exec to execute multiple top-level expressions

### DIFF
--- a/embed/finch.c
+++ b/embed/finch.c
@@ -116,7 +116,7 @@ extern void finch_initialize(){
                 fmt = Printf.Format(proc)\n\
                 args = [gensym(Symbol(:arg, n)) for n in 1:length(fmt.formats)]\n\
                 proc = Printf.format(fmt, (\"var$(repr(string(arg)))\" for arg in args)...)\n\
-                body = Meta.parse(proc)\n\
+                body = Meta.parse(\"begin $proc end\")\n\
                 eval(quote\n\
                     function $(gensym(:exec))($(args...))\n\
                         $body\n\


### PR DESCRIPTION
finch_exec was failing for multiple lines of code because Meta.parse stops at new line and only considers one top level expression at a time, I just enclosed the input to Meta.parse in a `begin end` block.