### PR TITLE
Add benchmarks for bfs and sssp

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -7,7 +7,8 @@ Pkg.resolve()
 
 using Finch
 using BenchmarkTools
-
+using RewriteTools
+using Finch.IndexNotation: or_, choose
 using MatrixDepot
 using SparseArrays
 
@@ -107,6 +108,104 @@ end
 SUITE["graphs"]["pagerank"] = BenchmarkGroup()
 for mtx in ["SNAP/soc-Epinions1", "SNAP/soc-LiveJournal1"]
     SUITE["graphs"]["pagerank"][mtx] = @benchmarkable pagerank($(fiber(SparseMatrixCSC(matrixdepot(mtx))))) 
+end
+
+function bfs(edges, source=5)
+    (n, m) = size(edges)
+
+    @assert n == m
+    F_in = @fiber sl(n, e(0))
+    F_out = @fiber sl(n, e(0))
+    F_tmp = @fiber sl(n, e(0))
+    @finch @loop j F_in[j] = (j == $source)
+
+    P_in = @fiber d(n, e(0))
+    P_out = @fiber d(n, e(0))
+    P_tmp = @fiber d(n, e(0))
+    @finch @loop j P_in[j] = (j == $source) * (0 - 2) + (j != $source) * (0 - 1)
+
+    V = @fiber d(n, e(0))
+    B = @fiber d(n, e(0))
+    w = Scalar{0}()
+
+    while !iszero(F_in.lvl.lvl.val)
+        @finch @loop j V[j] = (P_in[j] == (0 - 1))
+    
+        @finch (@loop j @loop k (begin
+            F_out[j] <<or_>>= w[]
+            B[j] <<choose>>= w[] * k
+        end
+            where (w[] = edges[j, k] * F_in[k] * V[j]) ) )
+        
+            @finch @loop j P_out[j] = choose(B[j], P_in[j])
+       
+        P_tmp = P_in
+        P_in = P_out
+        P_out = P_tmp
+
+        F_tmp = F_in
+        F_in = F_out
+        F_out = F_tmp
+    end
+
+    return P_in
+end
+
+SUITE["graphs"]["bfs"] = BenchmarkGroup()
+for mtx in ["SNAP/soc-Epinions1", "SNAP/soc-LiveJournal1"]
+    SUITE["graphs"]["bfs"][mtx] = @benchmarkable bfs($(fiber(SparseMatrixCSC(matrixdepot(mtx))))) 
+end
+
+# For sssp we should probably compress priorityQ on both dimensions, since many entires in rowptr will be equal
+# ( due to many rows being zero )
+function sssp(weights, source=1)
+    (n, m) = size(weights)
+    @assert n == m
+    P = n
+    val = typemax(Int64)
+    
+    priorityQ_in = @fiber d(P, sl(n, e(0)))
+    priorityQ_out = @fiber d(P, sl(n, e(0)))
+    tmp_priorityQ = @fiber d(P, sl(n, e(0)))
+    @finch @loop p (@loop j priorityQ_in[p, j] = (p == 1 && j == $source) + (p == $P && j != $source))
+
+    dist_in = @fiber d(n, e($val))
+    dist_out = @fiber d(n, e($val))
+    tmp_dist = @fiber d(n, e($val))
+    @finch @loop j dist_in[j] = ifelse(j == $source, 0, $val)
+
+    B = @fiber d(n, e($val))
+    slice = @fiber d(n, e(0))
+    priority = 1
+
+    while !iszero(priorityQ_in.lvl.lvl.lvl.val) && priority <= P
+
+        @finch @loop j slice[j] = priorityQ_in[$priority, j]
+
+        while !iszero(slice.lvl.lvl.val) 
+            @finch @loop j (@loop k B[j] <<min>>= ifelse(weights[j, k] * priorityQ_in[$priority, k] != 0, weights[j, k] + dist_in[k], $val))
+            @finch @loop j dist_out[j] = min(B[j], dist_in[j])
+            @finch @loop j (@loop k priorityQ_out[j, k] = (dist_in[k] > dist_out[k]) * (dist_out[k] == j-1) + (dist_in[k] == dist_out[k] && j != $priority) * priorityQ_in[j, k])
+            @finch @loop j slice[j] = priorityQ_out[$priority, j]
+            
+            tmp_dist = dist_in
+            dist_in = dist_out
+            dist_out = tmp_dist
+
+            tmp_priorityQ = priorityQ_in
+            priorityQ_in = priorityQ_out
+            priorityQ_out = tmp_priorityQ
+        end
+
+        priority += 1
+    end 
+    
+    return dist_in
+end
+
+SUITE["graphs"]["sssp"] = BenchmarkGroup()
+for mtx in ["SNAP/soc-Epinions1", "SNAP/soc-LiveJournal1"]
+    SUITE["graphs"]["sssp"][mtx] = @benchmarkable sssp($(fiber(SparseMatrixCSC(matrixdepot(mtx))))) 
 end
 
 foreach(((k, v),) -> BenchmarkTools.warmup(v), SUITE)

--- a/src/Finch.jl
+++ b/src/Finch.jl
@@ -24,7 +24,7 @@ include("util.jl")
 include("semantics.jl")
 include("IndexNotation/IndexNotation.jl")
 using .IndexNotation
-using .IndexNotation: and, or
+using .IndexNotation: and, or, or_, choose
 include("virtualize.jl")
 include("style.jl")
 include("transform_ssa.jl")

--- a/src/IndexNotation/syntax.jl
+++ b/src/IndexNotation/syntax.jl
@@ -49,6 +49,10 @@ or() = false
 or(x) = x
 or(x, y, tail...) = x || or(y, tail...)
 
+or_(x,y) = x == 1|| y == 1
+
+choose(x, y) = ifelse(x!=0, x, y)
+
 function _finch_capture(ex, ctx)
     #extra sugar
     if ex isa Expr && ex.head == :macrocall && length(ex.args) >= 3 && ex.args[1] == Symbol("@∀")

--- a/src/annihilate.jl
+++ b/src/annihilate.jl
@@ -121,6 +121,28 @@
             @f @multi (c[j...] += $(extent(a)) * $d) @chunk $i a @f(@multi b... e...)
         end
     end),
+    (@rule @f(@chunk $i $a ($b[j...] <<choose>>= $d)) => if Finch.isliteral(d) && i ∉ j
+        @f (b[j...] <<choose>>= $d)
+    end),
+    (@rule @f(@chunk $i $a @multi b... ($c[j...] <<choose>>= $d) e...) => begin
+        if Finch.isliteral(d) && i ∉ j
+            @f @multi (c[j...] <<choose>>= $d) @chunk $i a @f(@multi b... e...)
+        end
+    end),
+    (@rule @f(choose(0, $a)) => a),
+    (@rule @f(choose($a, 0)) => a),
+    (@rule @f(@chunk $i $a ($b[j...] <<or_>>= $d)) => if Finch.isliteral(d) && i ∉ j
+        @f (b[j...] <<or_>>= $d)
+    end),
+    (@rule @f(@chunk $i $a @multi b... ($c[j...] <<or_>>= $d) e...) => begin
+        if Finch.isliteral(d) && i ∉ j
+            @f @multi (c[j...] <<or_>>= $d) @chunk $i a @f(@multi b... e...)
+        end
+    end),
+    (@rule @f(or_(false, $a)) => a),
+    (@rule @f(or_($a, false)) => a),
+    (@rule @f(or_($a, true)) => true),
+    (@rule @f(or_(true, $a)) => true),
 ]
 
 @kwdef mutable struct Simplify


### PR DESCRIPTION
Couldn't run either of them to completion, so if you can take a look and see what's slowing things down that would be great! I think there should be a more efficient way to store the priority queue in SSSP, but maybe there's other stuff as well.