### PR TITLE
Code cleanups for debugger

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -182,17 +182,18 @@ level_default
 
 It's easy to ask Finch to advance a few steps in its compiler pipeline. The basic functionality is documented via the following bit of code:
 ```
+using Finch
+using Finch: @finch_program_instance, begin_debug, step_code, iscompiled, end_debug
+
 y = @fiber d(e(0.0))
 A = @fiber d(sl(e(0.0)))
 x = @fiber sl(e(0.0))
-
-
 
 code = Finch.@finch_program_instance begin
    @loop j i y[i] += A[i, j] * x[j]
 end
 
-debug = Finch.stage_code(code)
+debug = begin_debug(code)
 
 while true
     global debug = step_code(debug, sdisplay=false) # Runs one step of compilation
@@ -205,7 +206,7 @@ ret = end_debug(debug) # extracts code from debugging context.
 # Prints compiled code
 ```
 
-The function `stage_code(code; algebra)` takes a `finch_program_instance` plus an optional algebra
+The function `begin_debug(code; algebra)` takes a `finch_program_instance` plus an optional algebra
 and creates a debugging context for it, called a `PartialCode`. The function `step_code(debug; steps, sdisplay)` takes a debugging 
 context and advances some number of `steps`, displaying the results automatically if `sdisplay`.
 Finally, `iscompiled` checks if the code in a debug context is completely compiled and `end_debug` extracts the code,
@@ -213,7 +214,7 @@ throwing an error if the code is not completely compiled.
 
 
 ```@docs
-stage_code
+begin_debug
 step_code
 iscompiled
 end_debug

--- a/src/FinchNotation/nodes.jl
+++ b/src/FinchNotation/nodes.jl
@@ -674,12 +674,10 @@ function display_statement(io, mime, node::FinchNode, indent)
         print(io, " "^indent * "begin\n")
         for body in node.bodies
             display_statement(io, mime, body, indent + 2)
-            println()
+            println(io)
         end
         print(io, " "^indent * "end")
     else
-        println("oh no")
-        println(node)
         error("unimplemented")
     end
 end

--- a/src/FinchNotation/nodes.jl
+++ b/src/FinchNotation/nodes.jl
@@ -1,5 +1,3 @@
-tab = "  "
-
 const IS_TREE = 1
 const IS_STATEFUL = 2
 const IS_CONST = 4
@@ -619,9 +617,9 @@ function display_expression(io, mime, node::FinchNode)
     end
 end
 
-function display_statement(io, mime, node::FinchNode, level)
+function display_statement(io, mime, node::FinchNode, indent)
     if node.kind === loop
-        print(io, tab^level * "@∀ ")
+        print(io, " "^indent * "@∀ ")
         while node.kind === loop
             display_expression(io, mime, node.idx)
             print(io, " = ")
@@ -630,10 +628,10 @@ function display_statement(io, mime, node::FinchNode, level)
             node = node.body
         end
         print(io," (\n")
-        display_statement(io, mime, node, level + 1)
-        print(io, tab^level * ")")
+        display_statement(io, mime, node, indent + 2)
+        print(io, " "^indent * ")")
     elseif node.kind === sieve
-        print(io, tab^level * "if ")
+        print(io, " "^indent * "if ")
         while node.body.kind === sieve
             display_expression(io, mime, node.cond)
             print(io," && ")
@@ -641,10 +639,10 @@ function display_statement(io, mime, node::FinchNode, level)
         end
         display_expression(io, mime, node.cond)
         node = node.body
-        display_statement(io, mime, node, level + 1)
-        print(io, tab^level * "end")
+        display_statement(io, mime, node, indent + 2)
+        print(io, " "^indent * "end")
     elseif node.kind === assign
-        print(io, tab^level)
+        print(io, " "^indent)
         display_expression(io, mime, node.lhs)
         print(io, " <<")
         display_expression(io, mime, node.op)
@@ -655,30 +653,30 @@ function display_statement(io, mime, node::FinchNode, level)
         print(io, "::")
         display_expression(io, mime, ex.mode)
     elseif node.kind === declare
-        print(io, tab^level * "@declare(")
+        print(io, " "^indent * "@declare(")
         display_expression(io, mime, node.tns)
         print(io, ", ")
         display_expression(io, mime, node.init)
         print(io, ")")
     elseif node.kind === freeze
-        print(io, tab^level * "@freeze(")
+        print(io, " "^indent * "@freeze(")
         display_expression(io, mime, node.tns)
         print(io, ")")
     elseif node.kind === forget
-        print(io, tab^level * "@forget(")
+        print(io, " "^indent * "@forget(")
         display_expression(io, mime, node.tns)
         print(io, ")")
     elseif node.kind === thaw
-        print(io, tab^level * "@thaw(")
+        print(io, " "^indent * "@thaw(")
         display_expression(io, mime, node.tns)
         print(io, ")")
     elseif node.kind === sequence
-        print(io, tab^level * "begin\n")
+        print(io, " "^indent * "begin\n")
         for body in node.bodies
-            display_statement(io, mime, body, level + 1)
+            display_statement(io, mime, body, indent + 2)
             println()
         end
-        print(io, tab^level * "end")
+        print(io, " "^indent * "end")
     else
         println("oh no")
         println(node)

--- a/src/resumables.jl
+++ b/src/resumables.jl
@@ -23,32 +23,29 @@ end
 
 show_with_indent(io, node, indent, prec) = (print("@finch("); Base.show_unquoted(io, node, indent, prec); print(")"))
 function show_with_indent(io, node::FinchNode, indent, prec)
-    indent = fld(indent, 2) + 1
     if Finch.FinchNotation.isstateful(node)
         println("@finch begin")
-        Finch.FinchNotation.display_statement(io, MIME"text/plain"(), node, indent)
+        Finch.FinchNotation.display_statement(io, MIME"text/plain"(), node, indent + 2)
         println()
-        print("  "^(indent - 1), "end")
+        print(" "^indent, "end")
     else
         print("@finch("); Finch.FinchNotation.display_expression(io, MIME"text/plain"(), node); print(")")
     end
 end
 
 function show_with_indent_meta(io, node::FinchNode, indent, prec, meta)
-    indent = fld(indent, 2) + 1
     if Finch.FinchNotation.isstateful(node)
         print("@finch begin")
         println(meta)
-        Finch.FinchNotation.display_statement(io, MIME"text/plain"(), node, indent)
+        Finch.FinchNotation.display_statement(io, MIME"text/plain"(), node, indent + 2)
         println()
-        print("  "^(indent - 1), "end")
+        print(" "^indent, "end")
     else
         print("@finch("); print(meta); Finch.FinchNotation.display_expression(io, MIME"text/plain"(), node); print(")")
     end
 end
 
 function show_with_indent_meta(io, node, indent, prec, meta)
-    indent = fld(indent, 2) + 1
     print("@finch("); print(meta); Finch.FinchNotation.display_expression(io, MIME"text/plain"(), node); print(")")
 end
 
@@ -84,7 +81,7 @@ function number_resumables(code)
     counter = 0
     Postwalk(node -> 
                     if node isa Resumable 
-                        node.meta[:Number] = counter
+                        node.meta[:number] = counter
                         counter+=1 
                         node
                     else
@@ -96,7 +93,7 @@ function record_methods(code)
     Postwalk(node -> 
     if node isa Resumable 
         loc = which(lower, (typeof(node.root), typeof(node.ctx), typeof(node.style)))
-         node.meta[:Which] = (splitpath(string(loc.file))[end], loc.line)
+         node.meta[:which] = (splitpath(string(loc.file))[end], loc.line)
         node
     else
         node
@@ -241,8 +238,8 @@ end
 function should_resume(c :: StepOnlyControl, ctx, node, style, meta)
     should = false
     if !isnothing(c.resumeLocations) && !isnothing(meta)
-        if :Number in keys(meta) 
-            should = meta[:Number] in c.resumeLocations
+        if :number in keys(meta) 
+            should = meta[:number] in c.resumeLocations
         end
     end
     if !isnothing(c.resumeStyles)
@@ -291,12 +288,12 @@ end
  end
 
  """
-    stage_code(code; algebra = DefaultAlgebra(), sdisplay=true)
+    begin_debug(code; algebra = DefaultAlgebra(), sdisplay=true)
 
 Takes a Finch Program and stages it within a DebugContext, defined within a particualr algebra.
 Displays the initial code if `sdisplay`.
  """
-function stage_code(code; algebra = DefaultAlgebra(),  sdisplay=true)
+function begin_debug(code; algebra = DefaultAlgebra(),  sdisplay=true)
     ctx = DebugContext(LowerJulia(algebra = algebra), SimpleStepControl(step=0))
     code = execute_code(:ex, typeof(code), algebra, ctx=ctx)
     control = StepOnlyControl(step=step, resumeLocations = [0])

--- a/src/resumables.jl
+++ b/src/resumables.jl
@@ -29,7 +29,7 @@ function show_resumable(io, node::Resumable, indent, prec)
         print(io, "}")
     end
     if node.root isa FinchNode && Finch.FinchNotation.isstateful(node.root)
-        println(io, "begin")
+        println(io, " begin")
         Finch.FinchNotation.display_statement(io, MIME"text/plain"(), node.root, indent + 2);
         println(io)
         print(io, " "^indent*"end")
@@ -247,7 +247,7 @@ function Base.show(io::IO, code::PartialCode)
 end
 
 
- function clean_partial_code(pcode:: PartialCode; sdisplay=true)
+ function clean_partial_code(pcode:: PartialCode; sdisplay=false)
     code = striplines(pcode.code)
     code = unblock(code)
     code = number_resumables(code)
@@ -260,11 +260,11 @@ end
  end
 
  """
-    begin_debug(code; algebra = DefaultAlgebra(), sdisplay=true)
+    begin_debug(code; algebra = DefaultAlgebra(), sdisplay=false)
 
 Takes a Finch Program and stages it within a DebugContext, defined within a particualr algebra.
  """
-function begin_debug(code; algebra = DefaultAlgebra(),  sdisplay=true)
+function begin_debug(code; algebra = DefaultAlgebra(),  sdisplay=false)
     ctx = DebugContext(LowerJulia(algebra = algebra), SimpleStepControl(step=0))
     code = execute_code(:ex, typeof(code), algebra, ctx=ctx)
     control = StepOnlyControl(step=step, resumeLocations = [0])
@@ -272,18 +272,18 @@ function begin_debug(code; algebra = DefaultAlgebra(),  sdisplay=true)
 end
 
 """
-    step_all_code(code::PartialCode; step=1, sdisplay=true)
+    step_all_code(code::PartialCode; step=1, sdisplay=false)
 
 Experimental feature: Do not use explictly."""
-function step_all_code(code::PartialCode; step=1, sdisplay=true)
+function step_all_code(code::PartialCode; step=1, sdisplay=false)
     newcode = resume_lowering(SimpleStepControl(step=step), code.code)
     clean_partial_code(PartialCode(SimpleStepControl(step=step), newcode), sdisplay=sdisplay)
 end
 """
-    repeat_step_code(code::PartialCode; control=nothing, sdisplay=true)
+    repeat_step_code(code::PartialCode; control=nothing, sdisplay=false)
 
 Experimental feature: Do not use explictly."""
-function repeat_step_code(code::PartialCode; control=nothing, sdisplay=true)
+function repeat_step_code(code::PartialCode; control=nothing, sdisplay=false)
     if isnothing(control)
         newcode = resume_lowering(code.lastControl, code.code)
         clean_partial_code(PartialCode(code.lastControl, newcode),sdisplay=sdisplay)
@@ -294,20 +294,20 @@ function repeat_step_code(code::PartialCode; control=nothing, sdisplay=true)
 end
 
 """
-    step_some_code(code::PartialCode; step=1, resumeLocations=nothing, resumeStyles=nothing, resumeFilter=nothing, sdisplay=true)
+    step_some_code(code::PartialCode; step=1, resumeLocations=nothing, resumeStyles=nothing, resumeFilter=nothing, sdisplay=false)
 
 Experimental feature: Do not use explictly."""
-function step_some_code(code::PartialCode; step=1, resumeLocations=nothing, resumeStyles=nothing, resumeFilter=nothing, sdisplay=true)
+function step_some_code(code::PartialCode; step=1, resumeLocations=nothing, resumeStyles=nothing, resumeFilter=nothing, sdisplay=false)
     control = StepOnlyControl(step=step, resumeLocations = resumeLocations, resumeStyles=resumeStyles, resumeFilter=resumeFilter)
     repeat_step_code(code, control=control, sdisplay=sdisplay)
 end
 
 """
-    step_code(code::PartialCode; step=1, sdisplay=true)
+    step_code(code::PartialCode; step=1, sdisplay=false)
 
 Advance the compiler on `code` for `step`, displaying the code at the end if `sdisplay`.
 """
-function step_code(code::PartialCode; step=1, sdisplay=true)
+function step_code(code::PartialCode; step=1, sdisplay=false)
     control = StepOnlyControl(step=step, resumeLocations = [0])
     repeat_step_code(code, control=control, sdisplay=sdisplay)
 end

--- a/test/reference64/debug_spmv_resume.txt
+++ b/test/reference64/debug_spmv_resume.txt
@@ -6,159 +6,19 @@ Any[quote
     A_lvl_3 = A_lvl_2.lvl
     x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
     x_lvl_2 = x_lvl.lvl
-    y_lvl.shape::Int64 == A_lvl_2.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape::Int64) != $(A_lvl_2.shape::Int64))"))
-    A_lvl.shape::Int64 == x_lvl.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape::Int64) != $(A_lvl_2.shape::Int64))"))
-    A_lvl.shape::Int64 == x_lvl.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape::Int64) != $(A_lvl_2.shape::Int64))"))
-    A_lvl.shape::Int64 == x_lvl.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape::Int64))"))
-    A_lvl.shape::Int64 == x_lvl.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape::Int64 == x_lvl.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape::Int64 || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape::Int64) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape::Int64))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-          begin
-        @thaw(y)        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-          @thaw(y)
-          begin
+    @finch{#0,lower.jl:174}(y_lvl.shape::Int64) == @finch{#0,lower.jl:174}(A_lvl_2.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(y_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(A_lvl_2.shape::Int64)))"))
+    @finch{#0,lower.jl:174}(A_lvl.shape::Int64) == @finch{#0,lower.jl:174}(x_lvl.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
         @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -167,14 +27,145 @@ end, quote
     A_lvl_3 = A_lvl_2.lvl
     x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
     x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-          begin
+    y_lvl.shape == @finch{#0,lower.jl:174}(A_lvl_2.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(y_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(A_lvl_2.shape::Int64)))"))
+    @finch{#0,lower.jl:174}(A_lvl.shape::Int64) == @finch{#0,lower.jl:174}(x_lvl.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
         @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-          y[i] <<+>>= *(x[j], A[i, j])        )        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(y_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(A_lvl_2.shape::Int64)))"))
+    @finch{#0,lower.jl:174}(A_lvl.shape::Int64) == @finch{#0,lower.jl:174}(x_lvl.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(@finch{#0,lower.jl:174}(A_lvl_2.shape::Int64)))"))
+    @finch{#0,lower.jl:174}(A_lvl.shape::Int64) == @finch{#0,lower.jl:174}(x_lvl.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    @finch{#0,lower.jl:174}(A_lvl.shape::Int64) == @finch{#0,lower.jl:174}(x_lvl.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == @finch{#0,lower.jl:174}(x_lvl.shape::Int64) || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(@finch{#0,lower.jl:174}(A_lvl.shape::Int64)) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(@finch{#0,lower.jl:174}(x_lvl.shape::Int64)))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -185,13 +176,82 @@ end, quote
     x_lvl_2 = x_lvl.lvl
     y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
     A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+    @finch{#0,lower.jl:174} begin
+      begin
+        @thaw(y)
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    @finch{#0,lower.jl:174} begin
+      @thaw(y)
+    end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    @finch{#0,lower.jl:174} begin
+      begin
+        @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+          y[i] <<+>>= *(x[j], A[i, j])        )
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    @finch{#0,unfurl.jl:39} begin
+      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Furlable)[j], virtual(Finch.Furlable)[i, j])      )
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -202,13 +262,18 @@ end, quote
     x_lvl_2 = x_lvl.lvl
     y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
     A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+    @finch{#0,thunks.jl:33} begin
+      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])      )
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -219,8 +284,8 @@ end, quote
     x_lvl_2 = x_lvl.lvl
     y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
     A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    x_lvl_q = x_lvl.ptr[@finch{#0,lower.jl:174}(1)]
+    x_lvl_q_stop = x_lvl.ptr[@finch{#0,lower.jl:174}(1) + 1]
     if x_lvl_q < x_lvl_q_stop
         x_lvl_i = x_lvl.idx[x_lvl_q]
         x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
@@ -228,13 +293,18 @@ end, quote
         x_lvl_i = 1
         x_lvl_i1 = 0
     end
-    res =           @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+    res = @finch{#0,pipelines.jl:26} begin
+          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Pipeline)[j], virtual(Finch.Lookup)[i, j])          )
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -246,7 +316,7 @@ end, quote
     y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
     A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
     x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    x_lvl_q_stop = x_lvl.ptr[@finch{#0,lower.jl:174}(1) + 1]
     if x_lvl_q < x_lvl_q_stop
         x_lvl_i = x_lvl.idx[x_lvl_q]
         x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
@@ -254,13 +324,18 @@ end, quote
         x_lvl_i = 1
         x_lvl_i1 = 0
     end
-    res =           @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+    res = @finch{#0,pipelines.jl:26} begin
+          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Pipeline)[j], virtual(Finch.Lookup)[i, j])          )
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -280,44 +355,18 @@ end, quote
         x_lvl_i = 1
         x_lvl_i1 = 0
     end
-    res =           @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+    res = @finch{#0,pipelines.jl:26} begin
+          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Pipeline)[j], virtual(Finch.Lookup)[i, j])          )
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -338,87 +387,24 @@ end, quote
         x_lvl_i1 = 0
     end
     res = begin
-            j = 1
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            j = @finch{#0,lower.jl:174}(1)
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) >= cached(phase_start, 1)
-                j_4 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= cached(phase_start, 1)
-                j_4 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -440,55 +426,23 @@ end, quote
     end
     res = begin
             j = 1
-            if phase_stop >= cached(phase_start, 1)
-                j_4 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -510,58 +464,285 @@ end, quote
     end
     res = begin
             j = 1
-            if phase_stop >= phase_start
+            if @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) >= @finch{#0,lower.jl:174}(cached(phase_start, 1))
                 j_4 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                @finch{#0,steppers.jl:29} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))
-                    j_start_2 = j
-                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                        virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                      )
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if @finch{#0,lower.jl:174}(phase_stop) >= @finch{#0,lower.jl:174}(cached(phase_start, 1))
+                j_4 = j
+                @finch{#0,steppers.jl:29} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= @finch{#0,lower.jl:174}(cached(phase_start, 1))
+                j_4 = j
+                @finch{#0,steppers.jl:29} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= @finch{#0,lower.jl:174}(phase_start)
+                j_4 = j
+                @finch{#0,steppers.jl:29} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                @finch{#0,steppers.jl:29} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Stepper)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)))
+                    j_start_2 = j
+                    @finch{#0,thunks.jl:33} begin
+                      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                        virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                      )
+                    end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= @finch{#0,lower.jl:174}(phase_stop)
+                    j_start_2 = j
+                    @finch{#0,thunks.jl:33} begin
+                      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                        virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                      )
+                    end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -587,57 +768,26 @@ end, quote
                 j_4 = j
                 while j <= phase_stop
                     j_start_2 = j
-                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    @finch{#0,thunks.jl:33} begin
+                      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                      )
+                    end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
     end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                        virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                      )
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -664,19 +814,26 @@ end, quote
                 while j <= phase_stop
                     j_start_2 = j
                     x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 =                           @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    res_2 = @finch{#0,phases.jl:53} begin
+                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Step)[j], virtual(Finch.Lookup)[i, j])                          )
+                        end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -705,21 +862,28 @@ end, quote
                     x_lvl_i = x_lvl.idx[x_lvl_q]
                     res_2 = begin
                             j_5 = j
-                                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                            @finch{#0,switches.jl:61} begin
+                              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Switch)[j], virtual(Finch.Lookup)[i, j])                              )
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -748,26 +912,35 @@ end, quote
                     x_lvl_i = x_lvl.idx[x_lvl_q]
                     res_2 = begin
                             j_5 = j
-                            if x_lvl_i == cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                            if @finch{#0,lower.jl:174}(@finch{#0,lower.jl:174}(x_lvl_i) == @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))))
+                                @finch{#0,thunks.jl:33} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -796,26 +969,35 @@ end, quote
                     x_lvl_i = x_lvl.idx[x_lvl_q]
                     res_2 = begin
                             j_5 = j
-                            if x_lvl_i == cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                            if @finch{#0,lower.jl:174}(x_lvl_i) == @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))))
+                                @finch{#0,thunks.jl:33} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -844,26 +1026,92 @@ end, quote
                     x_lvl_i = x_lvl.idx[x_lvl_q]
                     res_2 = begin
                             j_5 = j
-                            if x_lvl_i == cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                            if x_lvl_i == @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))))
+                                @finch{#0,thunks.jl:33} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == @finch{#0,lower.jl:174}(phase_stop_2)
+                                @finch{#0,thunks.jl:33} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -893,25 +1141,34 @@ end, quote
                     res_2 = begin
                             j_5 = j
                             if x_lvl_i == phase_stop_2
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,thunks.jl:33} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -941,129 +1198,36 @@ end, quote
                     res_2 = begin
                             j_5 = j
                             if x_lvl_i == phase_stop_2
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 =                                       @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                res_3 = @finch{#0,spikes.jl:25} begin
+                                      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Spike)[j], virtual(Finch.Lookup)[i, j])                                      )
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                            virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                            virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1094,30 +1258,106 @@ end, quote
                             j_5 = j
                             if x_lvl_i == phase_stop_2
                                 res_3 = begin
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        @finch{#0,runs.jl:22} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                            virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
+                                        end
+                                        @finch{#0,runs.jl:22} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                            virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
+                                        end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        @finch{#0,fills.jl:24} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Fill)[], virtual(Finch.Lookup)[i, j])                                          )
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        end
+                                        @finch{#0,runs.jl:22} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
+                                        end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1148,30 +1388,41 @@ end, quote
                             j_5 = j
                             if x_lvl_i == phase_stop_2
                                 res_3 = begin
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        @finch{#0,simplify_program.jl:170} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Simplify), virtual(Finch.Lookup)[i, j])                                          )
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        end
+                                        @finch{#0,runs.jl:22} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
+                                        end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1202,30 +1453,41 @@ end, quote
                             j_5 = j
                             if x_lvl_i == phase_stop_2
                                 res_3 = begin
-                                                                                  begin
+                                        @finch{#0,lower.jl:174} begin
+                                          begin
                                           end
-                                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        end
+                                        @finch{#0,runs.jl:22} begin
+                                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                             virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                          )
+                                        end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1255,27 +1517,36 @@ end, quote
                     res_2 = begin
                             j_5 = j
                             if x_lvl_i == phase_stop_2
-                                res_3 =                                       @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                res_3 = @finch{#0,runs.jl:22} begin
+                                      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                      )
+                                    end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1305,27 +1576,36 @@ end, quote
                     res_2 = begin
                             j_5 = j
                             if x_lvl_i == phase_stop_2
-                                res_3 =                                       @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                res_3 = @finch{#0,thunks.jl:33} begin
+                                      @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Thunk)[], virtual(Finch.Lookup)[i, j])                                      )
+                                    end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1356,29 +1636,38 @@ end, quote
                             j_5 = j
                             if x_lvl_i == phase_stop_2
                                 res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q::Int64]
-                                        res_4 =                                               @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        x_lvl_2_val_2 = x_lvl_2.val[@finch{#0,lower.jl:174}(x_lvl_q::Int64)]
+                                        res_4 = @finch{#0,lower.jl:174} begin
+                                              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Lookup)[i, j])                                              )
+                                            end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1410,28 +1699,37 @@ end, quote
                             if x_lvl_i == phase_stop_2
                                 res_3 = begin
                                         x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 =                                               @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                        res_4 = @finch{#0,lower.jl:174} begin
+                                              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Lookup)[i, j])                                              )
+                                            end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1464,30 +1762,104 @@ end, quote
                                 res_3 = begin
                                         x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
                                         res_4 = begin
-                                                j_6 = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))
-                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                j_6 = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))))
+                                                @finch{#0,thunks.jl:33} begin
+                                                  @∀ i = virtual(Finch.Extent)  (
                                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                  )
+                                                end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = @finch{#0,lower.jl:174}(phase_stop_2)
+                                                @finch{#0,thunks.jl:33} begin
+                                                  @∀ i = virtual(Finch.Extent)  (
+                                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                  )
+                                                end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1521,29 +1893,38 @@ end, quote
                                         x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
                                         res_4 = begin
                                                 j_6 = phase_stop_2
-                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                @finch{#0,thunks.jl:33} begin
+                                                  @∀ i = virtual(Finch.Extent)  (
                                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                  )
+                                                end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1577,86 +1958,39 @@ end, quote
                                         x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
                                         res_4 = begin
                                                 j_6 = phase_stop_2
-                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                  )
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape::Int64 + j_6
-                                                res_5 =                                                       @∀ i = virtual(Finch.Extent)  (
+                                                A_lvl_q = (@finch{#0,lower.jl:174}(1) - 1) * @finch{#0,lower.jl:174}(A_lvl.shape::Int64) + @finch{#0,lower.jl:174}(j_6)
+                                                res_5 = @finch{#0,unfurl.jl:39} begin
+                                                      @∀ i = virtual(Finch.Extent)  (
                                                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Furlable)[i])                                                      )
+                                                    end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1690,30 +2024,105 @@ end, quote
                                         x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
                                         res_4 = begin
                                                 j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape::Int64 + j_6
-                                                res_5 =                                                       @∀ i = virtual(Finch.Extent)  (
+                                                A_lvl_q = (1 - 1) * @finch{#0,lower.jl:174}(A_lvl.shape::Int64) + @finch{#0,lower.jl:174}(j_6)
+                                                res_5 = @finch{#0,unfurl.jl:39} begin
+                                                      @∀ i = virtual(Finch.Extent)  (
                                                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Furlable)[i])                                                      )
+                                                    end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + @finch{#0,lower.jl:174}(j_6)
+                                                res_5 = @finch{#0,unfurl.jl:39} begin
+                                                      @∀ i = virtual(Finch.Extent)  (
+                                                        virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Furlable)[i])                                                      )
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1748,29 +2157,38 @@ end, quote
                                         res_4 = begin
                                                 j_6 = phase_stop_2
                                                 A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 =                                                       @∀ i = virtual(Finch.Extent)  (
+                                                res_5 = @finch{#0,unfurl.jl:39} begin
+                                                      @∀ i = virtual(Finch.Extent)  (
                                                         virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Furlable)[i])                                                      )
+                                                    end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1805,86 +2223,38 @@ end, quote
                                         res_4 = begin
                                                 j_6 = phase_stop_2
                                                 A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 =                                                       @∀ i = virtual(Finch.Extent)  (
-                                                        virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Furlable)[i])                                                      )
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 =                                                       @∀ i = virtual(Finch.Extent)  (
+                                                res_5 = @finch{#0,thunks.jl:33} begin
+                                                      @∀ i = virtual(Finch.Extent)  (
                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                      )
+                                                    end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1920,8 +2290,8 @@ end, quote
                                                 j_6 = phase_stop_2
                                                 A_lvl_q = (1 - 1) * A_lvl.shape + j_6
                                                 res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q::Int64]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q::Int64 + 1]
+                                                        A_lvl_2_q = A_lvl_2.ptr[@finch{#0,lower.jl:174}(A_lvl_q::Int64)]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[@finch{#0,lower.jl:174}(A_lvl_q::Int64) + 1]
                                                         if A_lvl_2_q < A_lvl_2_q_stop
                                                             A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
                                                             A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
@@ -1929,30 +2299,39 @@ end, quote
                                                             A_lvl_2_i = 1
                                                             A_lvl_2_i1 = 0
                                                         end
-                                                        res_6 =                                                               @∀ i = virtual(Finch.Extent)  (
+                                                        res_6 = @finch{#0,pipelines.jl:26} begin
+                                                              @∀ i = virtual(Finch.Extent)  (
                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Pipeline)[i])                                                              )
+                                                            end
                                                     end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -1989,7 +2368,7 @@ end, quote
                                                 A_lvl_q = (1 - 1) * A_lvl.shape + j_6
                                                 res_5 = begin
                                                         A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q::Int64 + 1]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[@finch{#0,lower.jl:174}(A_lvl_q::Int64) + 1]
                                                         if A_lvl_2_q < A_lvl_2_q_stop
                                                             A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
                                                             A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
@@ -1997,30 +2376,39 @@ end, quote
                                                             A_lvl_2_i = 1
                                                             A_lvl_2_i1 = 0
                                                         end
-                                                        res_6 =                                                               @∀ i = virtual(Finch.Extent)  (
+                                                        res_6 = @finch{#0,pipelines.jl:26} begin
+                                                              @∀ i = virtual(Finch.Extent)  (
                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Pipeline)[i])                                                              )
+                                                            end
                                                     end
                                             end
                                     end
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2065,80 +2453,9 @@ end, quote
                                                             A_lvl_2_i = 1
                                                             A_lvl_2_i1 = 0
                                                         end
-                                                        res_6 =                                                               @∀ i = virtual(Finch.Extent)  (
+                                                        res_6 = @finch{#0,pipelines.jl:26} begin
+                                                              @∀ i = virtual(Finch.Extent)  (
                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Pipeline)[i])                                                              )
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
                                                             end
                                                     end
                                             end
@@ -2146,22 +2463,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2207,165 +2531,15 @@ end, quote
                                                             A_lvl_2_i1 = 0
                                                         end
                                                         res_6 = begin
-                                                                i = 1
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                i = @finch{#0,lower.jl:174}(1)
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) >= cached(phase_start_3, 1)
-                                                                    i_4 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= cached(phase_start_3, 1)
-                                                                    i_4 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
                                                             end
                                                     end
                                             end
@@ -2373,22 +2547,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2435,91 +2616,14 @@ end, quote
                                                         end
                                                         res_6 = begin
                                                                 i = 1
-                                                                if phase_stop_3 >= cached(phase_start_3, 1)
-                                                                    i_4 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
                                                             end
                                                     end
                                             end
@@ -2527,22 +2631,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2589,94 +2700,18 @@ end, quote
                                                         end
                                                         res_6 = begin
                                                                 i = 1
-                                                                if phase_stop_3 >= phase_start_3
+                                                                if @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) >= @finch{#0,lower.jl:174}(cached(phase_start_3, 1))
                                                                     i_4 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,steppers.jl:29} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
-                                                                end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))
-                                                                        i_start_2 = i
-                                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                            virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                          )
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -2684,22 +2719,563 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if @finch{#0,lower.jl:174}(phase_stop_3) >= @finch{#0,lower.jl:174}(cached(phase_start_3, 1))
+                                                                    i_4 = i
+                                                                    @finch{#0,steppers.jl:29} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= @finch{#0,lower.jl:174}(cached(phase_start_3, 1))
+                                                                    i_4 = i
+                                                                    @finch{#0,steppers.jl:29} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= @finch{#0,lower.jl:174}(phase_start_3)
+                                                                    i_4 = i
+                                                                    @finch{#0,steppers.jl:29} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    @finch{#0,steppers.jl:29} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Stepper)[i])                                                                      )
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)))
+                                                                        i_start_2 = i
+                                                                        @finch{#0,thunks.jl:33} begin
+                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                            virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                          )
+                                                                        end
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= @finch{#0,lower.jl:174}(phase_stop_3)
+                                                                        i_start_2 = i
+                                                                        @finch{#0,thunks.jl:33} begin
+                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                            virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                          )
+                                                                        end
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2750,13 +3326,17 @@ end, quote
                                                                     i_4 = i
                                                                     while i <= phase_stop_3
                                                                         i_start_2 = i
-                                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                        @finch{#0,thunks.jl:33} begin
+                                                                          @∀ i = virtual(Finch.Extent)  (
                                                                             virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                          )
+                                                                        end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -2764,102 +3344,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
     end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                            virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                          )
-                                                                    end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
-                                                                end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2911,13 +3418,17 @@ end, quote
                                                                     while i <= phase_stop_3
                                                                         i_start_2 = i
                                                                         A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 =                                                                               @∀ i = virtual(Finch.Extent)  (
+                                                                        res_7 = @finch{#0,phases.jl:53} begin
+                                                                              @∀ i = virtual(Finch.Extent)  (
                                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Step)[i])                                                                              )
+                                                                            end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -2925,22 +3436,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -2994,15 +3512,19 @@ end, quote
                                                                         A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
                                                                         res_7 = begin
                                                                                 i_5 = i
-                                                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                                @finch{#0,switches.jl:61} begin
+                                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Switch)[i])                                                                                  )
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                end
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3010,22 +3532,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3079,20 +3608,26 @@ end, quote
                                                                         A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
                                                                         res_7 = begin
                                                                                 i_5 = i
-                                                                                if A_lvl_2_i == cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                if @finch{#0,lower.jl:174}(@finch{#0,lower.jl:174}(A_lvl_2_i) == @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))))
+                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                                      )
+                                                                                    end
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3100,22 +3635,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3169,20 +3711,26 @@ end, quote
                                                                         A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
                                                                         res_7 = begin
                                                                                 i_5 = i
-                                                                                if A_lvl_2_i == cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                if @finch{#0,lower.jl:174}(A_lvl_2_i) == @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))))
+                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                                      )
+                                                                                    end
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3190,22 +3738,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3259,20 +3814,26 @@ end, quote
                                                                         A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
                                                                         res_7 = begin
                                                                                 i_5 = i
-                                                                                if A_lvl_2_i == cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                if A_lvl_2_i == @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))))
+                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                                      )
+                                                                                    end
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3280,22 +3841,132 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == @finch{#0,lower.jl:174}(phase_stop_4)
+                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                                      )
+                                                                                    end
+                                                                                else
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
+                                                                                end
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
+                                                                            end
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3350,19 +4021,25 @@ end, quote
                                                                         res_7 = begin
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                                      )
+                                                                                    end
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3370,22 +4047,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3440,207 +4124,27 @@ end, quote
                                                                         res_7 = begin
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[i])                                                                                      )
-                                                                                else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
-                                                                                end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
-                                                                            end
-                                                                    end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
-                                                                end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 =                                                                                           @∀ i = virtual(Finch.Extent)  (
+                                                                                    res_8 = @finch{#0,spikes.jl:25} begin
+                                                                                          @∀ i = virtual(Finch.Extent)  (
                                                                                             virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Spike)[i])                                                                                          )
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
-                                                                                end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
-                                                                            end
-                                                                    end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
-                                                                end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                                                virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                                                virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3648,22 +4152,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3719,24 +4230,143 @@ end, quote
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
                                                                                     res_8 = begin
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                            @finch{#0,runs.jl:22} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
+                                                                                                virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
+                                                                                            end
+                                                                                            @finch{#0,runs.jl:22} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
+                                                                                                virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
+                                                                                            end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
+                                                                                end
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
+                                                                            end
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            @finch{#0,fills.jl:24} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
                                                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Fill)[])                                                                                              )
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                            end
+                                                                                            @finch{#0,runs.jl:22} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
                                                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
+                                                                                            end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3744,22 +4374,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3815,24 +4452,32 @@ end, quote
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
                                                                                     res_8 = begin
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                            @finch{#0,simplify_program.jl:170} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
                                                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Simplify))                                                                                              )
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                            end
+                                                                                            @finch{#0,runs.jl:22} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
                                                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
+                                                                                            end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3840,22 +4485,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -3911,24 +4563,32 @@ end, quote
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
                                                                                     res_8 = begin
-                                                                                                                                                                                          begin
+                                                                                            @finch{#0,lower.jl:174} begin
+                                                                                              begin
                                                                                               end
-                                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                            end
+                                                                                            @finch{#0,runs.jl:22} begin
+                                                                                              @∀ i = virtual(Finch.Extent)  (
                                                                                                 virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                              )
+                                                                                            end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -3936,22 +4596,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4006,21 +4673,27 @@ end, quote
                                                                         res_7 = begin
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 =                                                                                           @∀ i = virtual(Finch.Extent)  (
+                                                                                    res_8 = @finch{#0,runs.jl:22} begin
+                                                                                          @∀ i = virtual(Finch.Extent)  (
                                                                                             virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                          )
+                                                                                        end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4028,22 +4701,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4098,21 +4778,27 @@ end, quote
                                                                         res_7 = begin
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 =                                                                                           @∀ i = virtual(Finch.Extent)  (
+                                                                                    res_8 = @finch{#0,thunks.jl:33} begin
+                                                                                          @∀ i = virtual(Finch.Extent)  (
                                                                                             virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Thunk)[])                                                                                          )
+                                                                                        end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4120,22 +4806,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4191,23 +4884,29 @@ end, quote
                                                                                 i_5 = i
                                                                                 if A_lvl_2_i == phase_stop_4
                                                                                     res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q::Int64]
-                                                                                            res_9 =                                                                                                   @∀ i = virtual(Finch.Extent)  (
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[@finch{#0,lower.jl:174}(A_lvl_2_q::Int64)]
+                                                                                            res_9 = @finch{#0,lower.jl:174} begin
+                                                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])                                                                                                  )
+                                                                                                end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4215,22 +4914,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4287,22 +4993,28 @@ end, quote
                                                                                 if A_lvl_2_i == phase_stop_4
                                                                                     res_8 = begin
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 =                                                                                                   @∀ i = virtual(Finch.Extent)  (
+                                                                                            res_9 = @finch{#0,lower.jl:174} begin
+                                                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])                                                                                                  )
+                                                                                                end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4310,22 +5022,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4383,23 +5102,29 @@ end, quote
                                                                                     res_8 = begin
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
                                                                                             res_9 = begin
-                                                                                                    i_6 = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))
-                                                                                                                                                                                                          virtual(Finch.Thunk)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    i_6 = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))))
+                                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                                      virtual(Finch.Thunk)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4407,22 +5132,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4480,23 +5212,29 @@ end, quote
                                                                                     res_8 = begin
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
                                                                                             res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                                                                                                                          virtual(Finch.Thunk)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    i_6 = @finch{#0,lower.jl:174}(phase_stop_4)
+                                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                                      virtual(Finch.Thunk)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4504,119 +5242,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
     end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                                                                                                                          virtual(Finch.Thunk)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
-                                                                                end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
-                                                                            end
-                                                                    end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
-                                                                end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4675,23 +5323,28 @@ end, quote
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape::Int64 + i_6
-                                                                                                    res_10 =                                                                                                           virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    @finch{#0,thunks.jl:33} begin
+                                                                                                      virtual(Finch.Thunk)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4699,22 +5352,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4773,23 +5433,29 @@ end, quote
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape::Int64 + i_6
-                                                                                                    res_10 =                                                                                                           virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    y_lvl_q = (@finch{#0,lower.jl:174}(1) - 1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64) + @finch{#0,lower.jl:174}(i_6)
+                                                                                                    res_10 = @finch{#0,lower.jl:174} begin
+                                                                                                          virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                        end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4797,22 +5463,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4871,23 +5544,29 @@ end, quote
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 =                                                                                                           virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    y_lvl_q = (1 - 1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64) + @finch{#0,lower.jl:174}(i_6)
+                                                                                                    res_10 = @finch{#0,lower.jl:174} begin
+                                                                                                          virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                        end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4895,22 +5574,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -4969,23 +5655,29 @@ end, quote
                                                                                             A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 =                                                                                                           virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + @finch{#0,lower.jl:174}(i_6)
+                                                                                                    res_10 = @finch{#0,lower.jl:174} begin
+                                                                                                          virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                        end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -4993,22 +5685,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5068,22 +5767,28 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (virtual(Finch.VirtualScalar)[] = +(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = @finch{#0,lower.jl:174} begin
+                                                                                                          virtual(Finch.VirtualScalar)[] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])
+                                                                                                        end
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5091,22 +5796,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5166,22 +5878,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q::Int64] = +(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (@finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[]) = @finch{#0,lower.jl:174}(+(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5189,22 +5905,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5264,22 +5987,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = +(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[@finch{#0,lower.jl:174}(y_lvl_q::Int64)] = @finch{#0,lower.jl:174}(+(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5287,22 +6014,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5362,22 +6096,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = @finch{#0,lower.jl:174}(+(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5385,22 +6123,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5460,22 +6205,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (@finch{#0,lower.jl:174}(+))(@finch{#0,lower.jl:174}(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5483,22 +6232,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5558,22 +6314,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)(@finch{#0,lower.jl:174}(*(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[])), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5581,22 +6341,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5656,22 +6423,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(virtual(Finch.VirtualScalar)[], virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((@finch{#0,lower.jl:174}(*))(@finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[]), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5679,22 +6450,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5754,22 +6532,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, virtual(Finch.VirtualScalar)[]), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(@finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[]), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5777,22 +6559,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5852,22 +6641,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), virtual(Finch.VirtualScalar)[]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5875,22 +6668,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -5950,22 +6750,26 @@ end, quote
                                                                                             res_9 = begin
                                                                                                     i_6 = phase_stop_4
                                                                                                     y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q::Int64]))
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), @finch{#0,lower.jl:174}(virtual(Finch.VirtualScalar)[])))
                                                                                                 end
                                                                                         end
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -5973,22 +6777,138 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[@finch{#0,lower.jl:174}(y_lvl_q::Int64)]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
+                                                                                end
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
+                                                                            end
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
+                                                                end
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6054,16 +6974,20 @@ end, quote
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,runs.jl:22} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6071,22 +6995,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6152,16 +7083,20 @@ end, quote
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,fills.jl:24} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Fill)[])                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6169,22 +7104,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6250,16 +7192,20 @@ end, quote
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                                    @finch{#0,simplify_program.jl:170} begin
+                                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Simplify))                                                                                      )
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6267,22 +7213,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6348,16 +7301,20 @@ end, quote
                                                                                     A_lvl_2_q += 1
                                                                                     res_8
                                                                                 else
-                                                                                                                                                                          begin
+                                                                                    @finch{#0,lower.jl:174} begin
+                                                                                      begin
                                                                                       end
+                                                                                    end
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6365,22 +7322,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6447,13 +7411,15 @@ end, quote
                                                                                     res_8
                                                                                 else
                                                                                 end
-                                                                                i = cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1))))) + 1
+                                                                                i = @finch{#0,lower.jl:174}(cached(phase_stop_4, cached(min(phase_stop_3, A_lvl_2_i), min(cached(A_lvl_2_i, max(A_lvl_2_i, +(i_start_2, 1))), max(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)), +(i_start_2, 1)))))) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6461,22 +7427,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6543,13 +7516,15 @@ end, quote
                                                                                     res_8
                                                                                 else
                                                                                 end
-                                                                                i = phase_stop_4 + 1
+                                                                                i = @finch{#0,lower.jl:174}(phase_stop_4) + 1
                                                                             end
                                                                     end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6557,118 +7532,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
     end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1)) + 1
-                                                                end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
-                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6738,10 +7624,12 @@ end, quote
                                                                                 i = phase_stop_4 + 1
                                                                             end
                                                                     end
-                                                                    i = phase_stop_3 + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_3, min(y_lvl.shape::Int64, A_lvl_2_i1))) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6749,22 +7637,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6834,10 +7729,12 @@ end, quote
                                                                                 i = phase_stop_4 + 1
                                                                             end
                                                                     end
-                                                                    i = phase_stop_3 + 1
+                                                                    i = @finch{#0,lower.jl:174}(phase_stop_3) + 1
                                                                 end
-                                                                                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
                                                                     virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
                                                             end
                                                     end
                                             end
@@ -6845,22 +7742,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -6932,11 +7836,118 @@ end, quote
                                                                     end
                                                                     i = phase_stop_3 + 1
                                                                 end
-                                                                if cached(phase_stop_5, y_lvl.shape::Int64) >= cached(phase_start_5, max(1, +(1, A_lvl_2_i1)))
+                                                                @finch{#0,phases.jl:53} begin
+                                                                  @∀ i = virtual(Finch.Extent)  (
+                                                                    virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Phase)[i])                                                                  )
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) >= @finch{#0,lower.jl:174}(cached(phase_start_5, max(1, +(1, A_lvl_2_i1))))
                                                                     i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,runs.jl:22} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -6945,22 +7956,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7032,11 +8050,13 @@ end, quote
                                                                     end
                                                                     i = phase_stop_3 + 1
                                                                 end
-                                                                if phase_stop_5 >= cached(phase_start_5, max(1, +(1, A_lvl_2_i1)))
+                                                                if @finch{#0,lower.jl:174}(phase_stop_5) >= @finch{#0,lower.jl:174}(cached(phase_start_5, max(1, +(1, A_lvl_2_i1))))
                                                                     i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,runs.jl:22} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7045,22 +8065,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7132,11 +8159,13 @@ end, quote
                                                                     end
                                                                     i = phase_stop_3 + 1
                                                                 end
-                                                                if phase_stop_5 >= cached(phase_start_5, max(1, +(1, A_lvl_2_i1)))
+                                                                if phase_stop_5 >= @finch{#0,lower.jl:174}(cached(phase_start_5, max(1, +(1, A_lvl_2_i1))))
                                                                     i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,runs.jl:22} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7145,22 +8174,138 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= @finch{#0,lower.jl:174}(phase_start_5)
+                                                                    i_7 = i
+                                                                    @finch{#0,runs.jl:22} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
+                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                      )
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7234,9 +8379,11 @@ end, quote
                                                                 end
                                                                 if phase_stop_5 >= phase_start_5
                                                                     i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,runs.jl:22} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7245,22 +8392,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7334,109 +8488,11 @@ end, quote
                                                                 end
                                                                 if phase_stop_5 >= phase_start_5
                                                                     i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
-                                                                        virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Run)[i])                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,fills.jl:24} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Fill)[])                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7445,22 +8501,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7534,9 +8597,11 @@ end, quote
                                                                 end
                                                                 if phase_stop_5 >= phase_start_5
                                                                     i_7 = i
-                                                                                                                                          @∀ i = virtual(Finch.Extent)  (
+                                                                    @finch{#0,simplify_program.jl:170} begin
+                                                                      @∀ i = virtual(Finch.Extent)  (
                                                                         virtual(Finch.Lookup)[i] <<+>>= *(virtual(Finch.VirtualScalar)[], virtual(Finch.Simplify))                                                                      )
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7545,22 +8610,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7634,9 +8706,11 @@ end, quote
                                                                 end
                                                                 if phase_stop_5 >= phase_start_5
                                                                     i_7 = i
-                                                                                                                                          begin
+                                                                    @finch{#0,lower.jl:174} begin
+                                                                      begin
                                                                       end
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    end
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7645,22 +8719,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7734,7 +8815,7 @@ end, quote
                                                                 end
                                                                 if phase_stop_5 >= phase_start_5
                                                                     i_7 = i
-                                                                    i = cached(phase_stop_5, y_lvl.shape::Int64) + 1
+                                                                    i = @finch{#0,lower.jl:174}(cached(phase_stop_5, y_lvl.shape::Int64)) + 1
                                                                 end
                                                             end
                                                     end
@@ -7743,22 +8824,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -7832,7 +8920,7 @@ end, quote
                                                                 end
                                                                 if phase_stop_5 >= phase_start_5
                                                                     i_7 = i
-                                                                    i = phase_stop_5 + 1
+                                                                    i = @finch{#0,lower.jl:174}(phase_stop_5) + 1
                                                                 end
                                                             end
                                                     end
@@ -7841,120 +8929,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
     end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -8037,22 +9034,134 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,runs.jl:22} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                                  )
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                                @finch{#0,fills.jl:24} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Fill)[], virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -8135,22 +9244,29 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                                @finch{#0,simplify_program.jl:170} begin
+                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                                     virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Simplify), virtual(Finch.Lookup)[i, j])                                  )
+                                end
                             end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
                         end
                 end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
             end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
                 virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -8233,1695 +9349,1374 @@ end, quote
                                 x_lvl_q += 1
                                 res_3
                             else
-                                                                  begin
-                                  end
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1))))) + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)) + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-                          @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if cached(phase_stop_6, A_lvl.shape::Int64) >= cached(phase_start_6, max(1, +(1, x_lvl_i1)))
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= cached(phase_start_6, max(1, +(1, x_lvl_i1)))
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= cached(phase_start_6, max(1, +(1, x_lvl_i1)))
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Fill)[], virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
-                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Simplify), virtual(Finch.Lookup)[i, j])                  )
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
+                                @finch{#0,lower.jl:174} begin
                                   begin
+                                  end
+                                end
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = @finch{#0,lower.jl:174}(cached(phase_stop_2, cached(min(phase_stop, x_lvl_i), min(cached(x_lvl_i, max(x_lvl_i, +(j_start_2, 1))), max(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1)), +(j_start_2, 1)))))) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = @finch{#0,lower.jl:174}(phase_stop_2) + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop, min(A_lvl.shape::Int64, x_lvl_i1))) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = @finch{#0,lower.jl:174}(phase_stop) + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            @finch{#0,phases.jl:53} begin
+              @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Phase)[j], virtual(Finch.Lookup)[i, j])              )
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) >= @finch{#0,lower.jl:174}(cached(phase_start_6, max(1, +(1, x_lvl_i1))))
+                j_7 = j
+                @finch{#0,runs.jl:22} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if @finch{#0,lower.jl:174}(phase_stop_6) >= @finch{#0,lower.jl:174}(cached(phase_start_6, max(1, +(1, x_lvl_i1))))
+                j_7 = j
+                @finch{#0,runs.jl:22} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= @finch{#0,lower.jl:174}(cached(phase_start_6, max(1, +(1, x_lvl_i1))))
+                j_7 = j
+                @finch{#0,runs.jl:22} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= @finch{#0,lower.jl:174}(phase_start_6)
+                j_7 = j
+                @finch{#0,runs.jl:22} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                @finch{#0,runs.jl:22} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Run)[j], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                @finch{#0,fills.jl:24} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Fill)[], virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                @finch{#0,simplify_program.jl:170} begin
+                  @∀ j = virtual(Finch.Extent) i = virtual(Finch.Extent)  (
+                    virtual(Finch.Furlable)[i] <<+>>= *(virtual(Finch.Simplify), virtual(Finch.Lookup)[i, j])                  )
+                end
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                @finch{#0,lower.jl:174} begin
+                  begin
                   end
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
                 end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                j = cached(phase_stop_6, A_lvl.shape::Int64) + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
             end
         end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                j = phase_stop_6 + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                j = phase_stop_6 + 1
-            end
-        end
-          begin
-        @freeze(y)      end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                j = phase_stop_6 + 1
-            end
-        end
-          @freeze(y)
-          begin
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
       end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10012,14 +10807,118 @@ end, quote
             end
             if phase_stop_6 >= phase_start_6
                 j_7 = j
-                j = phase_stop_6 + 1
+                j = @finch{#0,lower.jl:174}(cached(phase_stop_6, A_lvl.shape::Int64)) + 1
             end
         end
-          begin
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
       end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                j = @finch{#0,lower.jl:174}(phase_stop_6) + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10113,9 +11012,14 @@ end, quote
                 j = phase_stop_6 + 1
             end
         end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      begin
+        @freeze(y)
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10209,9 +11113,404 @@ end, quote
                 j = phase_stop_6 + 1
             end
         end
-    qos = 1 * y_lvl.shape::Int64
-    resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    @finch{#0,lower.jl:174} begin
+      @freeze(y)
+    end
+    @finch{#0,lower.jl:174} begin
+      begin
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                j = phase_stop_6 + 1
+            end
+        end
+    @finch{#0,lower.jl:174} begin
+      begin
+      end
+    end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                j = phase_stop_6 + 1
+            end
+        end
+    qos = @finch{#0,lower.jl:174}(1) * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                j = phase_stop_6 + 1
+            end
+        end
+    qos = 1 * @finch{#0,lower.jl:174}(y_lvl.shape::Int64)
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
+end, quote
+    y_lvl = ex.body.body.lhs.tns.tns.lvl
+    y_lvl_2 = y_lvl.lvl
+    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
+    A_lvl_2 = A_lvl.lvl
+    A_lvl_3 = A_lvl_2.lvl
+    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
+    x_lvl_2 = x_lvl.lvl
+    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
+    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
+    x_lvl_q = x_lvl.ptr[1]
+    x_lvl_q_stop = x_lvl.ptr[1 + 1]
+    if x_lvl_q < x_lvl_q_stop
+        x_lvl_i = x_lvl.idx[x_lvl_q]
+        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
+    else
+        x_lvl_i = 1
+        x_lvl_i1 = 0
+    end
+    res = begin
+            j = 1
+            if phase_stop >= phase_start
+                j_4 = j
+                while j <= phase_stop
+                    j_start_2 = j
+                    x_lvl_i = x_lvl.idx[x_lvl_q]
+                    res_2 = begin
+                            j_5 = j
+                            if x_lvl_i == phase_stop_2
+                                res_3 = begin
+                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
+                                        res_4 = begin
+                                                j_6 = phase_stop_2
+                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
+                                                res_5 = begin
+                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
+                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
+                                                        if A_lvl_2_q < A_lvl_2_q_stop
+                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
+                                                        else
+                                                            A_lvl_2_i = 1
+                                                            A_lvl_2_i1 = 0
+                                                        end
+                                                        res_6 = begin
+                                                                i = 1
+                                                                if phase_stop_3 >= phase_start_3
+                                                                    i_4 = i
+                                                                    while i <= phase_stop_3
+                                                                        i_start_2 = i
+                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
+                                                                        res_7 = begin
+                                                                                i_5 = i
+                                                                                if A_lvl_2_i == phase_stop_4
+                                                                                    res_8 = begin
+                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
+                                                                                            res_9 = begin
+                                                                                                    i_6 = phase_stop_4
+                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
+                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
+                                                                                                end
+                                                                                        end
+                                                                                    A_lvl_2_q += 1
+                                                                                    res_8
+                                                                                else
+                                                                                end
+                                                                                i = phase_stop_4 + 1
+                                                                            end
+                                                                    end
+                                                                    i = phase_stop_3 + 1
+                                                                end
+                                                                if phase_stop_5 >= phase_start_5
+                                                                    i_7 = i
+                                                                    i = phase_stop_5 + 1
+                                                                end
+                                                            end
+                                                    end
+                                            end
+                                    end
+                                x_lvl_q += 1
+                                res_3
+                            else
+                            end
+                            j = phase_stop_2 + 1
+                        end
+                end
+                j = phase_stop + 1
+            end
+            if phase_stop_6 >= phase_start_6
+                j_7 = j
+                j = phase_stop_6 + 1
+            end
+        end
+    qos = 1 * y_lvl.shape
+    resize!(y_lvl_2.val, @finch{#0,lower.jl:174}(qos))
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10307,7 +11606,7 @@ end, quote
         end
     qos = 1 * y_lvl.shape
     resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    (y = @finch{#0,fibers.jl:27}(Finch.VirtualFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10403,7 +11702,7 @@ end, quote
         end
     qos = 1 * y_lvl.shape
     resize!(y_lvl_2.val, qos)
-    (y = VirtualFiber(d(e(0.0))),)
+    (y = Fiber(@finch{#0,denselevels.jl:109}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64)))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10499,7 +11798,7 @@ end, quote
         end
     qos = 1 * y_lvl.shape
     resize!(y_lvl_2.val, qos)
-    (y = Fiber(VirtualDenseLevel(VirtualElementLevel(:y_lvl_2, Float64, 0.0), :y_lvl, Int64, value(y_lvl.shape, Int64))),)
+    (y = Fiber((DenseLevel){Int64}(@finch{#0,elementlevels.jl:81}(Finch.VirtualElementLevel(:y_lvl_2, Float64, 0.0)), @finch{#0,lower.jl:174}(y_lvl.shape::Int64))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl
@@ -10595,103 +11894,7 @@ end, quote
         end
     qos = 1 * y_lvl.shape
     resize!(y_lvl_2.val, qos)
-    (y = Fiber((DenseLevel){Int64}(VirtualElementLevel(:y_lvl_2, Float64, 0.0), y_lvl.shape::Int64)),)
-end, quote
-    y_lvl = ex.body.body.lhs.tns.tns.lvl
-    y_lvl_2 = y_lvl.lvl
-    A_lvl = (ex.body.body.rhs.args[1]).tns.tns.lvl
-    A_lvl_2 = A_lvl.lvl
-    A_lvl_3 = A_lvl_2.lvl
-    x_lvl = (ex.body.body.rhs.args[2]).tns.tns.lvl
-    x_lvl_2 = x_lvl.lvl
-    y_lvl.shape == A_lvl_2.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(A_lvl_2.shape))"))
-    A_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(A_lvl.shape) != $(x_lvl.shape))"))
-    x_lvl_q = x_lvl.ptr[1]
-    x_lvl_q_stop = x_lvl.ptr[1 + 1]
-    if x_lvl_q < x_lvl_q_stop
-        x_lvl_i = x_lvl.idx[x_lvl_q]
-        x_lvl_i1 = x_lvl.idx[x_lvl_q_stop - 1]
-    else
-        x_lvl_i = 1
-        x_lvl_i1 = 0
-    end
-    res = begin
-            j = 1
-            if phase_stop >= phase_start
-                j_4 = j
-                while j <= phase_stop
-                    j_start_2 = j
-                    x_lvl_i = x_lvl.idx[x_lvl_q]
-                    res_2 = begin
-                            j_5 = j
-                            if x_lvl_i == phase_stop_2
-                                res_3 = begin
-                                        x_lvl_2_val_2 = x_lvl_2.val[x_lvl_q]
-                                        res_4 = begin
-                                                j_6 = phase_stop_2
-                                                A_lvl_q = (1 - 1) * A_lvl.shape + j_6
-                                                res_5 = begin
-                                                        A_lvl_2_q = A_lvl_2.ptr[A_lvl_q]
-                                                        A_lvl_2_q_stop = A_lvl_2.ptr[A_lvl_q + 1]
-                                                        if A_lvl_2_q < A_lvl_2_q_stop
-                                                            A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                            A_lvl_2_i1 = A_lvl_2.idx[A_lvl_2_q_stop - 1]
-                                                        else
-                                                            A_lvl_2_i = 1
-                                                            A_lvl_2_i1 = 0
-                                                        end
-                                                        res_6 = begin
-                                                                i = 1
-                                                                if phase_stop_3 >= phase_start_3
-                                                                    i_4 = i
-                                                                    while i <= phase_stop_3
-                                                                        i_start_2 = i
-                                                                        A_lvl_2_i = A_lvl_2.idx[A_lvl_2_q]
-                                                                        res_7 = begin
-                                                                                i_5 = i
-                                                                                if A_lvl_2_i == phase_stop_4
-                                                                                    res_8 = begin
-                                                                                            A_lvl_3_val_2 = A_lvl_3.val[A_lvl_2_q]
-                                                                                            res_9 = begin
-                                                                                                    i_6 = phase_stop_4
-                                                                                                    y_lvl_q = (1 - 1) * y_lvl.shape + i_6
-                                                                                                    res_10 = (y_lvl_2.val[y_lvl_q] = (+)((*)(x_lvl_2_val_2, A_lvl_3_val_2), y_lvl_2.val[y_lvl_q]))
-                                                                                                end
-                                                                                        end
-                                                                                    A_lvl_2_q += 1
-                                                                                    res_8
-                                                                                else
-                                                                                end
-                                                                                i = phase_stop_4 + 1
-                                                                            end
-                                                                    end
-                                                                    i = phase_stop_3 + 1
-                                                                end
-                                                                if phase_stop_5 >= phase_start_5
-                                                                    i_7 = i
-                                                                    i = phase_stop_5 + 1
-                                                                end
-                                                            end
-                                                    end
-                                            end
-                                    end
-                                x_lvl_q += 1
-                                res_3
-                            else
-                            end
-                            j = phase_stop_2 + 1
-                        end
-                end
-                j = phase_stop + 1
-            end
-            if phase_stop_6 >= phase_start_6
-                j_7 = j
-                j = phase_stop_6 + 1
-            end
-        end
-    qos = 1 * y_lvl.shape
-    resize!(y_lvl_2.val, qos)
-    (y = Fiber((DenseLevel){Int64}(y_lvl_2, y_lvl.shape::Int64)),)
+    (y = Fiber((DenseLevel){Int64}(y_lvl_2, @finch{#0,lower.jl:174}(y_lvl.shape::Int64))),)
 end, quote
     y_lvl = ex.body.body.lhs.tns.tns.lvl
     y_lvl_2 = y_lvl.lvl

--- a/test/test_debug.jl
+++ b/test/test_debug.jl
@@ -2,7 +2,7 @@
     @info "Testing Compiler Debugging"
     function test_debug_code(code; imax=10000)
         codes:: Vector{Any} = []
-        debug = Finch.stage_code(code)
+        debug = Finch.begin_debug(code)
         push!(codes, debug)
         i = 0
         while true

--- a/test/test_debug.jl
+++ b/test/test_debug.jl
@@ -6,7 +6,7 @@
         push!(codes, debug)
         i = 0
         while true
-            debug = Finch.step_code(debug, sdisplay=false)
+            debug = Finch.step_code(debug)
             push!(codes, debug)
             i+=1
             if i > imax


### PR DESCRIPTION
A summary of my changes:
- `Postwalk` should usually be surrounded by `Rewrite`. It returns nothing if the rewrite doesn't change anything, which is rarely what you want unless you're nesting it inside another rewriter.
- Consolidated the printing code into one function and made output prettier
- made `sdisplay` default to false
- rename `stage_code` to `begin_debug`
- fix the Finch printing code
- lowercase number and meta (tag names are like property names and are usually lowercase