### PR TITLE
Better error message for mixing reads and writes

### DIFF
--- a/src/transforms/lifecycle.jl
+++ b/src/transforms/lifecycle.jl
@@ -75,7 +75,7 @@ function (ctx::LifecycleVisitor)(node::FinchNode)
         idxs = map(ctx, node.idxs)
         uses = get(ctx.scoped_uses, getroot(node.tns), ctx.global_uses)
         get(uses, getroot(node.tns), node.mode).kind !== node.mode.kind &&
-            throw(LifecycleError("cannot mix reads and writes to $(node.tns) outside of defining scope (perhaps missing definition)"))
+            throw(LifecycleError("cannot mix reads and writes to $(node.tns) outside of defining scope (hint: perhaps add a declaration like `var .= 0` or use an updating operator like `var += 1`)"))
         uses[getroot(node.tns)] = node.mode
         access(node.tns, node.mode, idxs...)
     elseif istree(node)


### PR DESCRIPTION
Clearer error message for the following cases
~~~
               @finch begin
                         for j=_
                             for k=_
                                 temp[] = B[k, j]
                                 for i=_
                                     C[i, j] += temp[] * A[i, k]
                                 end
                             end
                         end
                     end
~~~
and
~~~
               @finch begin
                         for j=_
                             for k=_
                                 temp .= 0
                                 temp[] = B[k, j]
                                 for i=_
                                     C[i, j] = C[i, j] + temp[] * A[i, k]
                                 end
                             end
                         end
                     end
~~~
where in the former, `temp .= 0` is missing and in the latter, `C[i, j] = C[i, j] + temp[] * A[i, k]` should be replaced with `C[i, j] += temp[] * A[i, k]`.