### PR TITLE
Fix bug with indexing in diagonals 

### DIFF
--- a/src/transforms/concordize.jl
+++ b/src/transforms/concordize.jl
@@ -129,7 +129,7 @@ end
 function concordize(root, ctx::AbstractCompiler)
     depth = depth_calculator(root)
     root = Rewrite(Postwalk(Fixpoint(@rule access(~tns, ~mode, ~i..., ~j::isindex, ~k...) => begin
-        if depth(j) < maximum(depth.(k), init=0)
+        if depth(j) <= maximum(depth.(k), init=0)
             access(~tns, ~mode, ~i..., call(identity, j), ~k...)
         end
     end)))(root)

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -273,4 +273,13 @@ using CIndices
         end)
 
     end
+
+    #https://github.com/willow-ahrens/Finch.jl/issues/278
+
+    let
+        A = [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]
+        x = Scalar{0.0}()
+        @finch (x .= 0; for i = _ x[] += A[i, i] end)
+        @test x[] == 15.0
+    end
 end


### PR DESCRIPTION
Indexing into diagonals of tensors like in `@finch (x .= 0; for i = _ x[] += A[i, i] end)` was resulting in an error, as follows:

~~~
don't know how to lower Finch.Furlable(Finch.var"#1076#1079"{Finch.DenseTraversal, Vector{typeof(Finch.FinchNotation.defaultupdate)}, Symbol, DataType, Finch.FinchNotation.FinchNode, Finch.VirtualDenseLevel}(Finch.DenseTraversal(Finch.VirtualSubFiber{Finch.VirtualDenseLevel}(Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_3, Float64, 0.0), :y_lvl_2, Int64, value(y_lvl_2.shape, Int64)), value(y_lvl_q, Int64)), Finch.instantiate_updater, Finch.VirtualSubFiber), typeof(Finch.FinchNotation.defaultupdate)[], :y_lvl_2_q, Int64, value(y_lvl_q, Int64), Finch.VirtualDenseLevel(Finch.VirtualElementLevel(:y_lvl_3, Float64, 0.0), :y_lvl_2, Int64, value(y_lvl_2.shape, Int64))))
~~~