### PR TITLE
Wma/fix steppers

### DIFF
--- a/docs/src/interactive.ipynb
+++ b/docs/src/interactive.ipynb
@@ -49,11 +49,11 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.9.3"
+   "version": "1.6.7"
   },
   "kernelspec": {
-   "name": "julia-1.9",
-   "display_name": "Julia 1.9.3",
+   "name": "julia-1.6",
+   "display_name": "Julia 1.6.7",
    "language": "julia"
   }
  },

--- a/docs/src/interactive.ipynb
+++ b/docs/src/interactive.ipynb
@@ -15,7 +15,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/plain": "quote\n    y = ex.body.body.lhs.tns.bind\n    A_lvl = (ex.body.body.rhs.args[1]).tns.bind.lvl\n    A_lvl_2 = A_lvl.lvl\n    A_lvl_ptr = A_lvl_2.ptr\n    A_lvl_idx = A_lvl_2.idx\n    A_lvl_2_val = A_lvl_2.lvl.val\n    x = (ex.body.body.rhs.args[2]).tns.bind\n    sugar_1 = size(y)\n    y_mode1_stop = sugar_1[1]\n    A_lvl_2.shape == y_mode1_stop || throw(DimensionMismatch(\"mismatched dimension limits ($(A_lvl_2.shape) != $(y_mode1_stop))\"))\n    sugar_2 = size(x)\n    x_mode1_stop = sugar_2[1]\n    x_mode1_stop == A_lvl.shape || throw(DimensionMismatch(\"mismatched dimension limits ($(x_mode1_stop) != $(A_lvl.shape))\"))\n    for j_4 = 1:x_mode1_stop\n        A_lvl_q = (1 - 1) * A_lvl.shape + j_4\n        A_lvl_2_q = A_lvl_ptr[A_lvl_q]\n        A_lvl_2_q_stop = A_lvl_ptr[A_lvl_q + 1]\n        if A_lvl_2_q < A_lvl_2_q_stop\n            A_lvl_2_i1 = A_lvl_idx[A_lvl_2_q_stop - 1]\n        else\n            A_lvl_2_i1 = 0\n        end\n        phase_stop = min(A_lvl_2.shape, A_lvl_2_i1)\n        if phase_stop >= 1\n            i = 1\n            if A_lvl_idx[A_lvl_2_q] < 1\n                A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)\n            end\n            while i <= phase_stop\n                A_lvl_2_i = A_lvl_idx[A_lvl_2_q]\n                phase_stop_2 = min(phase_stop, A_lvl_2_i)\n                if A_lvl_2_i == phase_stop_2\n                    A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]\n                    y[phase_stop_2] = x[j_4] * A_lvl_3_val + y[phase_stop_2]\n                    A_lvl_2_q += 1\n                end\n                i = phase_stop_2 + 1\n            end\n        end\n    end\n    (y = y,)\nend"
+      "text/plain": "quote\n    y = ex.body.body.lhs.tns.bind\n    A_lvl = (ex.body.body.rhs.args[1]).tns.bind.lvl\n    A_lvl_2 = A_lvl.lvl\n    A_lvl_ptr = A_lvl_2.ptr\n    A_lvl_idx = A_lvl_2.idx\n    A_lvl_2_val = A_lvl_2.lvl.val\n    x = (ex.body.body.rhs.args[2]).tns.bind\n    sugar_1 = size(y)\n    y_mode1_stop = sugar_1[1]\n    A_lvl_2.shape == y_mode1_stop || throw(DimensionMismatch(\"mismatched dimension limits ($(A_lvl_2.shape) != $(y_mode1_stop))\"))\n    sugar_2 = size(x)\n    x_mode1_stop = sugar_2[1]\n    x_mode1_stop == A_lvl.shape || throw(DimensionMismatch(\"mismatched dimension limits ($(x_mode1_stop) != $(A_lvl.shape))\"))\n    for j_4 = 1:x_mode1_stop\n        A_lvl_q = (1 - 1) * A_lvl.shape + j_4\n        A_lvl_2_q = A_lvl_ptr[A_lvl_q]\n        A_lvl_2_q_stop = A_lvl_ptr[A_lvl_q + 1]\n        if A_lvl_2_q < A_lvl_2_q_stop\n            A_lvl_2_i1 = A_lvl_idx[A_lvl_2_q_stop - 1]\n        else\n            A_lvl_2_i1 = 0\n        end\n        phase_stop = min(A_lvl_2.shape, A_lvl_2_i1)\n        if phase_stop >= 1\n            if A_lvl_idx[A_lvl_2_q] < 1\n                A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)\n            end\n            while true\n                A_lvl_2_i = A_lvl_idx[A_lvl_2_q]\n                if A_lvl_2_i < phase_stop\n                    A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]\n                    y[A_lvl_2_i] = x[j_4] * A_lvl_3_val + y[A_lvl_2_i]\n                    A_lvl_2_q += 1\n                else\n                    phase_stop_3 = min(A_lvl_2_i, phase_stop)\n                    if A_lvl_2_i == phase_stop_3\n                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]\n                        y[phase_stop_3] = y[phase_stop_3] + x[j_4] * A_lvl_3_val\n                        A_lvl_2_q += 1\n                    end\n                    break\n                end\n            end\n        end\n    end\n    (y = y,)\nend"
      },
      "metadata": {},
      "execution_count": 1
@@ -49,11 +49,11 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.6.7"
+   "version": "1.9.3"
   },
   "kernelspec": {
-   "name": "julia-1.6",
-   "display_name": "Julia 1.6.7",
+   "name": "julia-1.9",
+   "display_name": "Julia 1.9.3",
    "language": "julia"
   }
  },

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -201,19 +201,24 @@ quote
     end
     phase_stop = min(A_lvl_i1, A_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if A_lvl_idx[A_lvl_q] < 1
             A_lvl_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_q, A_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             A_lvl_i = A_lvl_idx[A_lvl_q]
-            phase_stop_2 = min(phase_stop, A_lvl_i)
-            if A_lvl_i == phase_stop_2
+            if A_lvl_i < phase_stop
                 A_lvl_2_val = A_lvl_val[A_lvl_q]
                 s_val = A_lvl_2_val + s_val
                 A_lvl_q += 1
+            else
+                phase_stop_3 = min(A_lvl_i, phase_stop)
+                if A_lvl_i == phase_stop_3
+                    A_lvl_2_val = A_lvl_val[A_lvl_q]
+                    s_val = s_val + A_lvl_2_val
+                    A_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     (s = (Scalar){0, Int64}(s_val),)

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -55,19 +55,24 @@ quote
         end
         phase_stop = min(A_lvl_2_i1, A_lvl_2.shape)
         if phase_stop >= 1
-            i = 1
             if A_lvl_idx[A_lvl_2_q] < 1
                 A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                if A_lvl_2_i == phase_stop_2
+                if A_lvl_2_i < phase_stop
                     A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
                     s_val = A_lvl_3_val + s_val
                     A_lvl_2_q += 1
+                else
+                    phase_stop_3 = min(A_lvl_2_i, phase_stop)
+                    if A_lvl_2_i == phase_stop_3
+                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                        s_val = s_val + A_lvl_3_val
+                        A_lvl_2_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
     end
@@ -112,19 +117,24 @@ quote
             end
             phase_stop = min(i_3, A_lvl_2_i1)
             if phase_stop >= i_3
-                s_2 = i_3
                 if A_lvl_idx[A_lvl_2_q] < i_3
                     A_lvl_2_q = Finch.scansearch(A_lvl_idx, i_3, A_lvl_2_q, A_lvl_2_q_stop - 1)
                 end
-                while s_2 <= phase_stop
+                while true
                     A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                    phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                    if A_lvl_2_i == phase_stop_2
+                    if A_lvl_2_i < phase_stop
                         A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
                         s_val = A_lvl_3_val + s_val
                         A_lvl_2_q += 1
+                    else
+                        phase_stop_3 = min(A_lvl_2_i, phase_stop)
+                        if A_lvl_2_i == phase_stop_3
+                            A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                            s_val = s_val + A_lvl_3_val
+                            A_lvl_2_q += 1
+                        end
+                        break
                     end
-                    s_2 = phase_stop_2 + 1
                 end
             end
         end
@@ -249,28 +259,39 @@ quote
             if A_lvl_idx[A_lvl_2_q] < 1
                 A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                if A_lvl_2_i == phase_stop_2
-                    for i_6 = i:phase_stop_2 - 1
+                if A_lvl_2_i < phase_stop
+                    for i_6 = i:A_lvl_2_i - 1
                         C_val = f(0.0, B[i_6, j_4]) + C_val
                     end
                     A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
-                    C_val = C_val + f(A_lvl_3_val, B[phase_stop_2, j_4])
+                    C_val = C_val + f(A_lvl_3_val, B[A_lvl_2_i, j_4])
                     A_lvl_2_q += 1
+                    i = A_lvl_2_i + 1
                 else
-                    for i_8 = i:phase_stop_2
-                        C_val = f(0.0, B[i_8, j_4]) + C_val
+                    phase_stop_3 = min(A_lvl_2_i, phase_stop)
+                    if A_lvl_2_i == phase_stop_3
+                        for i_8 = i:phase_stop_3 - 1
+                            C_val = f(0.0, B[i_8, j_4]) + C_val
+                        end
+                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                        C_val = C_val + f(A_lvl_3_val, B[phase_stop_3, j_4])
+                        A_lvl_2_q += 1
+                    else
+                        for i_10 = i:phase_stop_3
+                            C_val = f(0.0, B[i_10, j_4]) + C_val
+                        end
                     end
+                    i = phase_stop_3 + 1
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
         phase_start_3 = max(1, 1 + A_lvl_2_i1)
         if B_mode1_stop >= phase_start_3
-            for i_10 = phase_start_3:B_mode1_stop
-                C_val = f(0.0, B[i_10, j_4]) + C_val
+            for i_12 = phase_start_3:B_mode1_stop
+                C_val = f(0.0, B[i_12, j_4]) + C_val
             end
         end
     end

--- a/test/reference64/concat_offset_permit.jl
+++ b/test/reference64/concat_offset_permit.jl
@@ -42,14 +42,12 @@ begin
         end
         phase_stop_3 = min(A_lvl_i1, phase_stop_2)
         if phase_stop_3 >= 1
-            i = 1
             if A_lvl_idx[A_lvl_q] < 1
                 A_lvl_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_q, A_lvl_q_stop - 1)
             end
-            while i <= phase_stop_3
+            while true
                 A_lvl_i = A_lvl_idx[A_lvl_q]
-                phase_stop_4 = min(phase_stop_3, A_lvl_i)
-                if A_lvl_i == phase_stop_4
+                if A_lvl_i < phase_stop_3
                     A_lvl_2_val = A_lvl_val[A_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
                         C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -58,18 +56,33 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = A_lvl_2_val
-                    C_lvl_idx[C_lvl_qos] = phase_stop_4
+                    C_lvl_idx[C_lvl_qos] = A_lvl_i
                     C_lvl_qos += 1
                     A_lvl_q += 1
+                else
+                    phase_stop_5 = min(A_lvl_i, phase_stop_3)
+                    if A_lvl_i == phase_stop_5
+                        A_lvl_2_val = A_lvl_val[A_lvl_q]
+                        if C_lvl_qos > C_lvl_qos_stop
+                            C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                            Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                            Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                        end
+                        C_lvl_val[C_lvl_qos] = A_lvl_2_val
+                        C_lvl_idx[C_lvl_qos] = phase_stop_5
+                        C_lvl_qos += 1
+                        A_lvl_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_4 + 1
             end
         end
     end
     phase_start_6 = max(1, 1 + A_lvl.shape)
-    phase_stop_6 = min(C_lvl.shape, 10)
-    if phase_stop_6 >= phase_start_6
-        for i_13 = phase_start_6:phase_stop_6
+    phase_stop_7 = min(C_lvl.shape, 10)
+    if phase_stop_7 >= phase_start_6
+        for i_14 = phase_start_6:phase_stop_7
             if C_lvl_qos > C_lvl_qos_stop
                 C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
                 Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
@@ -77,12 +90,12 @@ begin
                 Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
             end
             C_lvl_val[C_lvl_qos] = missing
-            C_lvl_idx[C_lvl_qos] = i_13
+            C_lvl_idx[C_lvl_qos] = i_14
             C_lvl_qos += 1
         end
     end
-    phase_stop_7 = min(C_lvl.shape, 0, 10 + B_lvl.shape)
-    if phase_stop_7 >= 11
+    phase_stop_8 = min(C_lvl.shape, 0, 10 + B_lvl.shape)
+    if phase_stop_8 >= 11
         B_lvl_q = B_lvl_ptr[1]
         B_lvl_q_stop = B_lvl_ptr[1 + 1]
         if B_lvl_q < B_lvl_q_stop
@@ -90,16 +103,15 @@ begin
         else
             B_lvl_i1 = 0
         end
-        phase_stop_8 = min(phase_stop_7, 10 + B_lvl_i1)
-        if phase_stop_8 >= 11
-            i = 11
+        phase_stop_9 = min(phase_stop_8, 10 + B_lvl_i1)
+        if phase_stop_9 >= 11
             if B_lvl_idx[B_lvl_q] < 11 + -10
                 B_lvl_q = Finch.scansearch(B_lvl_idx, 11 + -10, B_lvl_q, B_lvl_q_stop - 1)
             end
-            while i <= phase_stop_8
+            while true
                 B_lvl_i = B_lvl_idx[B_lvl_q]
-                phase_stop_9 = min(phase_stop_8, 10 + B_lvl_i)
-                if B_lvl_i == phase_stop_9 + -10
+                phase_stop_10 = 10 + B_lvl_i
+                if phase_stop_10 < phase_stop_9
                     B_lvl_2_val = B_lvl_val[B_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
                         C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -108,16 +120,31 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = B_lvl_2_val
-                    C_lvl_idx[C_lvl_qos] = phase_stop_9
+                    C_lvl_idx[C_lvl_qos] = phase_stop_10
                     C_lvl_qos += 1
                     B_lvl_q += 1
+                else
+                    phase_stop_11 = min(phase_stop_9, 10 + B_lvl_i)
+                    if B_lvl_i == phase_stop_11 + -10
+                        B_lvl_2_val = B_lvl_val[B_lvl_q]
+                        if C_lvl_qos > C_lvl_qos_stop
+                            C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                            Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                            Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                        end
+                        C_lvl_val[C_lvl_qos] = B_lvl_2_val
+                        C_lvl_idx[C_lvl_qos] = phase_stop_11
+                        C_lvl_qos += 1
+                        B_lvl_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_9 + 1
             end
         end
     end
-    phase_stop_11 = min(C_lvl.shape, A_lvl.shape, 10 + B_lvl.shape)
-    if phase_stop_11 >= 11
+    phase_stop_13 = min(C_lvl.shape, A_lvl.shape, 10 + B_lvl.shape)
+    if phase_stop_13 >= 11
         A_lvl_q = A_lvl_ptr[1]
         A_lvl_q_stop = A_lvl_ptr[1 + 1]
         if A_lvl_q < A_lvl_q_stop
@@ -132,8 +159,8 @@ begin
         else
             B_lvl_i1 = 0
         end
-        phase_stop_12 = min(A_lvl_i1, 10 + B_lvl_i1, phase_stop_11)
-        if phase_stop_12 >= 11
+        phase_stop_14 = min(A_lvl_i1, 10 + B_lvl_i1, phase_stop_13)
+        if phase_stop_14 >= 11
             i = 11
             if A_lvl_idx[A_lvl_q] < 11
                 A_lvl_q = Finch.scansearch(A_lvl_idx, 11, A_lvl_q, A_lvl_q_stop - 1)
@@ -141,11 +168,11 @@ begin
             if B_lvl_idx[B_lvl_q] < 11 + -10
                 B_lvl_q = Finch.scansearch(B_lvl_idx, 11 + -10, B_lvl_q, B_lvl_q_stop - 1)
             end
-            while i <= phase_stop_12
+            while i <= phase_stop_14
                 A_lvl_i = A_lvl_idx[A_lvl_q]
                 B_lvl_i = B_lvl_idx[B_lvl_q]
-                phase_stop_13 = min(A_lvl_i, 10 + B_lvl_i, phase_stop_12)
-                if A_lvl_i == phase_stop_13 && B_lvl_i == phase_stop_13 + -10
+                phase_stop_15 = min(A_lvl_i, 10 + B_lvl_i, phase_stop_14)
+                if A_lvl_i == phase_stop_15 && B_lvl_i == phase_stop_15 + -10
                     A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
                     B_lvl_2_val_2 = B_lvl_val[B_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
@@ -155,13 +182,13 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = coalesce(A_lvl_2_val_2, B_lvl_2_val_2)
-                    C_lvl_idx[C_lvl_qos] = phase_stop_13
+                    C_lvl_idx[C_lvl_qos] = phase_stop_15
                     C_lvl_qos += 1
                     A_lvl_q += 1
                     B_lvl_q += 1
-                elseif B_lvl_i == phase_stop_13 + -10
+                elseif B_lvl_i == phase_stop_15 + -10
                     B_lvl_q += 1
-                elseif A_lvl_i == phase_stop_13
+                elseif A_lvl_i == phase_stop_15
                     A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
                         C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -170,24 +197,22 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = coalesce(A_lvl_2_val_2, 0.0)
-                    C_lvl_idx[C_lvl_qos] = phase_stop_13
+                    C_lvl_idx[C_lvl_qos] = phase_stop_15
                     C_lvl_qos += 1
                     A_lvl_q += 1
                 end
-                i = phase_stop_13 + 1
+                i = phase_stop_15 + 1
             end
         end
-        phase_start_15 = max(11 + B_lvl_i1, 11)
-        phase_stop_15 = min(A_lvl_i1, phase_stop_11)
-        if phase_stop_15 >= phase_start_15
-            i = phase_start_15
-            if A_lvl_idx[A_lvl_q] < phase_start_15
-                A_lvl_q = Finch.scansearch(A_lvl_idx, phase_start_15, A_lvl_q, A_lvl_q_stop - 1)
+        phase_start_16 = max(11 + B_lvl_i1, 11)
+        phase_stop_17 = min(A_lvl_i1, phase_stop_13)
+        if phase_stop_17 >= phase_start_16
+            if A_lvl_idx[A_lvl_q] < phase_start_16
+                A_lvl_q = Finch.scansearch(A_lvl_idx, phase_start_16, A_lvl_q, A_lvl_q_stop - 1)
             end
-            while i <= phase_stop_15
+            while true
                 A_lvl_i = A_lvl_idx[A_lvl_q]
-                phase_stop_16 = min(A_lvl_i, phase_stop_15)
-                if A_lvl_i == phase_stop_16
+                if A_lvl_i < phase_stop_17
                     A_lvl_2_val_3 = A_lvl_val[A_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
                         C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -196,17 +221,32 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = coalesce(A_lvl_2_val_3, 0.0)
-                    C_lvl_idx[C_lvl_qos] = phase_stop_16
+                    C_lvl_idx[C_lvl_qos] = A_lvl_i
                     C_lvl_qos += 1
                     A_lvl_q += 1
+                else
+                    phase_stop_19 = min(A_lvl_i, phase_stop_17)
+                    if A_lvl_i == phase_stop_19
+                        A_lvl_2_val_3 = A_lvl_val[A_lvl_q]
+                        if C_lvl_qos > C_lvl_qos_stop
+                            C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                            Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                            Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                        end
+                        C_lvl_val[C_lvl_qos] = coalesce(A_lvl_2_val_3, 0.0)
+                        C_lvl_idx[C_lvl_qos] = phase_stop_19
+                        C_lvl_qos += 1
+                        A_lvl_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_16 + 1
             end
         end
     end
-    phase_start_18 = max(11, 1 + A_lvl.shape)
-    phase_stop_18 = min(C_lvl.shape, 10 + B_lvl.shape)
-    if phase_stop_18 >= phase_start_18
+    phase_start_19 = max(11, 1 + A_lvl.shape)
+    phase_stop_21 = min(C_lvl.shape, 10 + B_lvl.shape)
+    if phase_stop_21 >= phase_start_19
         B_lvl_q = B_lvl_ptr[1]
         B_lvl_q_stop = B_lvl_ptr[1 + 1]
         if B_lvl_q < B_lvl_q_stop
@@ -214,16 +254,15 @@ begin
         else
             B_lvl_i1 = 0
         end
-        phase_stop_19 = min(10 + B_lvl_i1, phase_stop_18)
-        if phase_stop_19 >= phase_start_18
-            i = phase_start_18
-            if B_lvl_idx[B_lvl_q] < phase_start_18 + -10
-                B_lvl_q = Finch.scansearch(B_lvl_idx, phase_start_18 + -10, B_lvl_q, B_lvl_q_stop - 1)
+        phase_stop_22 = min(10 + B_lvl_i1, phase_stop_21)
+        if phase_stop_22 >= phase_start_19
+            if B_lvl_idx[B_lvl_q] < phase_start_19 + -10
+                B_lvl_q = Finch.scansearch(B_lvl_idx, phase_start_19 + -10, B_lvl_q, B_lvl_q_stop - 1)
             end
-            while i <= phase_stop_19
+            while true
                 B_lvl_i = B_lvl_idx[B_lvl_q]
-                phase_stop_20 = min(10 + B_lvl_i, phase_stop_19)
-                if B_lvl_i == phase_stop_20 + -10
+                phase_stop_23 = 10 + B_lvl_i
+                if phase_stop_23 < phase_stop_22
                     B_lvl_2_val_4 = B_lvl_val[B_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
                         C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -232,18 +271,33 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = B_lvl_2_val_4
-                    C_lvl_idx[C_lvl_qos] = phase_stop_20
+                    C_lvl_idx[C_lvl_qos] = phase_stop_23
                     C_lvl_qos += 1
                     B_lvl_q += 1
+                else
+                    phase_stop_24 = min(10 + B_lvl_i, phase_stop_22)
+                    if B_lvl_i == phase_stop_24 + -10
+                        B_lvl_2_val_4 = B_lvl_val[B_lvl_q]
+                        if C_lvl_qos > C_lvl_qos_stop
+                            C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                            Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                            Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                        end
+                        C_lvl_val[C_lvl_qos] = B_lvl_2_val_4
+                        C_lvl_idx[C_lvl_qos] = phase_stop_24
+                        C_lvl_qos += 1
+                        B_lvl_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_20 + 1
             end
         end
     end
-    phase_start_22 = max(1, 11 + B_lvl.shape)
-    phase_stop_22 = min(C_lvl.shape, 0)
-    if phase_stop_22 >= phase_start_22
-        for i_35 = phase_start_22:phase_stop_22
+    phase_start_24 = max(1, 11 + B_lvl.shape)
+    phase_stop_26 = min(C_lvl.shape, 0)
+    if phase_stop_26 >= phase_start_24
+        for i_39 = phase_start_24:phase_stop_26
             if C_lvl_qos > C_lvl_qos_stop
                 C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
                 Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
@@ -251,13 +305,13 @@ begin
                 Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
             end
             C_lvl_val[C_lvl_qos] = missing
-            C_lvl_idx[C_lvl_qos] = i_35
+            C_lvl_idx[C_lvl_qos] = i_39
             C_lvl_qos += 1
         end
     end
-    phase_start_23 = max(1, 11 + B_lvl.shape)
-    phase_stop_23 = min(C_lvl.shape, A_lvl.shape)
-    if phase_stop_23 >= phase_start_23
+    phase_start_25 = max(1, 11 + B_lvl.shape)
+    phase_stop_27 = min(C_lvl.shape, A_lvl.shape)
+    if phase_stop_27 >= phase_start_25
         A_lvl_q = A_lvl_ptr[1]
         A_lvl_q_stop = A_lvl_ptr[1 + 1]
         if A_lvl_q < A_lvl_q_stop
@@ -265,16 +319,14 @@ begin
         else
             A_lvl_i1 = 0
         end
-        phase_stop_24 = min(A_lvl_i1, phase_stop_23)
-        if phase_stop_24 >= phase_start_23
-            i = phase_start_23
-            if A_lvl_idx[A_lvl_q] < phase_start_23
-                A_lvl_q = Finch.scansearch(A_lvl_idx, phase_start_23, A_lvl_q, A_lvl_q_stop - 1)
+        phase_stop_28 = min(A_lvl_i1, phase_stop_27)
+        if phase_stop_28 >= phase_start_25
+            if A_lvl_idx[A_lvl_q] < phase_start_25
+                A_lvl_q = Finch.scansearch(A_lvl_idx, phase_start_25, A_lvl_q, A_lvl_q_stop - 1)
             end
-            while i <= phase_stop_24
+            while true
                 A_lvl_i = A_lvl_idx[A_lvl_q]
-                phase_stop_25 = min(A_lvl_i, phase_stop_24)
-                if A_lvl_i == phase_stop_25
+                if A_lvl_i < phase_stop_28
                     A_lvl_2_val_4 = A_lvl_val[A_lvl_q]
                     if C_lvl_qos > C_lvl_qos_stop
                         C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -283,18 +335,33 @@ begin
                         Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                     end
                     C_lvl_val[C_lvl_qos] = A_lvl_2_val_4
-                    C_lvl_idx[C_lvl_qos] = phase_stop_25
+                    C_lvl_idx[C_lvl_qos] = A_lvl_i
                     C_lvl_qos += 1
                     A_lvl_q += 1
+                else
+                    phase_stop_30 = min(A_lvl_i, phase_stop_28)
+                    if A_lvl_i == phase_stop_30
+                        A_lvl_2_val_4 = A_lvl_val[A_lvl_q]
+                        if C_lvl_qos > C_lvl_qos_stop
+                            C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                            Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                            Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                        end
+                        C_lvl_val[C_lvl_qos] = A_lvl_2_val_4
+                        C_lvl_idx[C_lvl_qos] = phase_stop_30
+                        C_lvl_qos += 1
+                        A_lvl_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_25 + 1
             end
         end
     end
-    phase_start_27 = max(1, 1 + A_lvl.shape, 11 + B_lvl.shape)
-    phase_stop_27 = C_lvl.shape
-    if phase_stop_27 >= phase_start_27
-        for i_42 = phase_start_27:phase_stop_27
+    phase_start_29 = max(1, 1 + A_lvl.shape, 11 + B_lvl.shape)
+    phase_stop_32 = C_lvl.shape
+    if phase_stop_32 >= phase_start_29
+        for i_47 = phase_start_29:phase_stop_32
             if C_lvl_qos > C_lvl_qos_stop
                 C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
                 Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
@@ -302,7 +369,7 @@ begin
                 Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
             end
             C_lvl_val[C_lvl_qos] = missing
-            C_lvl_idx[C_lvl_qos] = i_42
+            C_lvl_idx[C_lvl_qos] = i_47
             C_lvl_qos += 1
         end
     end

--- a/test/reference64/convert_from_0 Fiber!(SparseByteMap(Element(false))).jl
+++ b/test/reference64/convert_from_0 Fiber!(SparseByteMap(Element(false))).jl
@@ -22,14 +22,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i_stop, tmp_lvl.shape)
     if phase_stop >= 1
-        i = 1
         while tmp_lvl_r + 1 < tmp_lvl_r_stop && last(tmp_lvl_srt[tmp_lvl_r]) < 1
             tmp_lvl_r += 1
         end
-        while i <= phase_stop
+        while true
             tmp_lvl_i = last(tmp_lvl_srt[tmp_lvl_r])
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 tmp_lvl_q = (1 - 1) * tmp_lvl.shape + tmp_lvl_i
                 tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
                 if res_lvl_qos > res_lvl_qos_stop
@@ -39,11 +37,27 @@ begin
                     Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
                 end
                 res = (res_lvl_val[res_lvl_qos] = tmp_lvl_2_val)
-                res_lvl_idx[res_lvl_qos] = phase_stop_2
+                res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                 res_lvl_qos += 1
                 tmp_lvl_r += 1
+            else
+                phase_stop_3 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_3
+                    tmp_lvl_q = (1 - 1) * tmp_lvl.shape + tmp_lvl_i
+                    tmp_lvl_2_val_2 = tmp_lvl_val[tmp_lvl_q]
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                        Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                    end
+                    res_lvl_val[res_lvl_qos] = tmp_lvl_2_val_2
+                    res_lvl_idx[res_lvl_qos] = phase_stop_3
+                    res_lvl_qos += 1
+                    tmp_lvl_r += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0 Fiber!(SparseCOO{1}(Element(false))).jl
+++ b/test/reference64/convert_from_0 Fiber!(SparseCOO{1}(Element(false))).jl
@@ -22,14 +22,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i_stop, tmp_lvl.shape[1])
     if phase_stop >= 1
-        i = 1
         if tmp_lvl_tbl1[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_tbl1, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_tbl1[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
@@ -38,11 +36,26 @@ begin
                     Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
                 end
                 res = (res_lvl_val[res_lvl_qos] = tmp_lvl_2_val)
-                res_lvl_idx[res_lvl_qos] = phase_stop_2
+                res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                 res_lvl_qos += 1
                 tmp_lvl_q += 1
+            else
+                phase_stop_3 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_3
+                    tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                        Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                    end
+                    res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
+                    res_lvl_idx[res_lvl_qos] = phase_stop_3
+                    res_lvl_qos += 1
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0 Fiber!(SparseHash{1}(Element(false))).jl
+++ b/test/reference64/convert_from_0 Fiber!(SparseHash{1}(Element(false))).jl
@@ -22,14 +22,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i_stop, tmp_lvl.shape[1])
     if phase_stop >= 1
-        i = 1
         while tmp_lvl_q + 1 < tmp_lvl_q_stop && (((tmp_lvl_srt[tmp_lvl_q])[1])[2])[1] < 1
             tmp_lvl_q += 1
         end
-        while i <= phase_stop
+        while true
             tmp_lvl_i = (((tmp_lvl_srt[tmp_lvl_q])[1])[2])[1]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 tmp_lvl_2_val = tmp_lvl_val[(tmp_lvl.srt[tmp_lvl_q])[2]]
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
@@ -38,11 +36,26 @@ begin
                     Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
                 end
                 res = (res_lvl_val[res_lvl_qos] = tmp_lvl_2_val)
-                res_lvl_idx[res_lvl_qos] = phase_stop_2
+                res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                 res_lvl_qos += 1
                 tmp_lvl_q += 1
+            else
+                phase_stop_3 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_3
+                    tmp_lvl_2_val = tmp_lvl_val[(tmp_lvl.srt[tmp_lvl_q])[2]]
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                        Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                    end
+                    res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
+                    res_lvl_idx[res_lvl_qos] = phase_stop_3
+                    res_lvl_qos += 1
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0 Fiber!(SparseList(Element(false))).jl
+++ b/test/reference64/convert_from_0 Fiber!(SparseList(Element(false))).jl
@@ -22,14 +22,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
@@ -38,11 +36,26 @@ begin
                     Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
                 end
                 res = (res_lvl_val[res_lvl_qos] = tmp_lvl_2_val)
-                res_lvl_idx[res_lvl_qos] = phase_stop_2
+                res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                 res_lvl_qos += 1
                 tmp_lvl_q += 1
+            else
+                phase_stop_3 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_3
+                    tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                        Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                    end
+                    res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
+                    res_lvl_idx[res_lvl_qos] = phase_stop_3
+                    res_lvl_qos += 1
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0 Fiber!(SparseRLE(Element(false))).jl
+++ b/test/reference64/convert_from_0 Fiber!(SparseRLE(Element(false))).jl
@@ -27,28 +27,50 @@ begin
         if tmp_lvl_right[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_right, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
+            i_start_2 = i
             tmp_lvl_i_start = tmp_lvl_left[tmp_lvl_q]
             tmp_lvl_i_stop = tmp_lvl_right[tmp_lvl_q]
-            phase_start_2 = i
-            phase_stop_2 = min(phase_stop, tmp_lvl_i_stop)
-            phase_start_4 = max(phase_start_2, tmp_lvl_i_start)
-            if phase_stop_2 >= phase_start_4
-                tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
-                for i_8 = phase_start_4:phase_stop_2
-                    if res_lvl_qos > res_lvl_qos_stop
-                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
-                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
-                        Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
-                        Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+            if tmp_lvl_i_stop < phase_stop
+                phase_start_3 = max(i_start_2, tmp_lvl_i_start)
+                if tmp_lvl_i_stop >= phase_start_3
+                    tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
+                    for i_8 = phase_start_3:tmp_lvl_i_stop
+                        if res_lvl_qos > res_lvl_qos_stop
+                            res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                            Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                        end
+                        res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
+                        res_lvl_idx[res_lvl_qos] = i_8
+                        res_lvl_qos += 1
                     end
-                    res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
-                    res_lvl_idx[res_lvl_qos] = i_8
-                    res_lvl_qos += 1
                 end
+                tmp_lvl_q += tmp_lvl_i_stop == tmp_lvl_i_stop
+                i = tmp_lvl_i_stop + 1
+            else
+                phase_start_4 = i
+                phase_stop_5 = min(tmp_lvl_i_stop, phase_stop)
+                phase_start_6 = max(tmp_lvl_i_start, phase_start_4)
+                if phase_stop_5 >= phase_start_6
+                    tmp_lvl_2_val_2 = tmp_lvl_val[tmp_lvl_q]
+                    for i_11 = phase_start_6:phase_stop_5
+                        if res_lvl_qos > res_lvl_qos_stop
+                            res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                            Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                        end
+                        res_lvl_val[res_lvl_qos] = tmp_lvl_2_val_2
+                        res_lvl_idx[res_lvl_qos] = i_11
+                        res_lvl_qos += 1
+                    end
+                end
+                tmp_lvl_q += phase_stop_5 == tmp_lvl_i_stop
+                i = phase_stop_5 + 1
+                break
             end
-            tmp_lvl_q += phase_stop_2 == tmp_lvl_i_stop
-            i = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0 Fiber!(SparseVBL(Element(false))).jl
+++ b/test/reference64/convert_from_0 Fiber!(SparseVBL(Element(false))).jl
@@ -27,31 +27,54 @@ begin
         if tmp_lvl_idx[tmp_lvl_r] < 1
             tmp_lvl_r = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_r, tmp_lvl_r_stop - 1)
         end
-        while i <= phase_stop
+        while true
+            i_start_2 = i
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_r]
             tmp_lvl_q_stop = tmp_lvl_ofs[tmp_lvl_r + 1]
             tmp_lvl_i_2 = tmp_lvl_i - (tmp_lvl_q_stop - tmp_lvl_ofs[tmp_lvl_r])
             tmp_lvl_q_ofs = (tmp_lvl_q_stop - tmp_lvl_i) - 1
-            phase_start_2 = i
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            phase_start_4 = max(phase_start_2, 1 + tmp_lvl_i_2)
-            if phase_stop_2 >= phase_start_4
-                for i_8 = phase_start_4:phase_stop_2
-                    if res_lvl_qos > res_lvl_qos_stop
-                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
-                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
-                        Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
-                        Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+            if tmp_lvl_i < phase_stop
+                phase_start_3 = max(i_start_2, 1 + tmp_lvl_i_2)
+                if tmp_lvl_i >= phase_start_3
+                    for i_8 = phase_start_3:tmp_lvl_i
+                        if res_lvl_qos > res_lvl_qos_stop
+                            res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                            Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                        end
+                        tmp_lvl_q = tmp_lvl_q_ofs + i_8
+                        tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
+                        res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
+                        res_lvl_idx[res_lvl_qos] = i_8
+                        res_lvl_qos += 1
                     end
-                    tmp_lvl_q = tmp_lvl_q_ofs + i_8
-                    tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q]
-                    res_lvl_val[res_lvl_qos] = tmp_lvl_2_val
-                    res_lvl_idx[res_lvl_qos] = i_8
-                    res_lvl_qos += 1
                 end
+                tmp_lvl_r += tmp_lvl_i == tmp_lvl_i
+                i = tmp_lvl_i + 1
+            else
+                phase_start_4 = i
+                phase_stop_5 = min(tmp_lvl_i, phase_stop)
+                phase_start_6 = max(1 + tmp_lvl_i_2, phase_start_4)
+                if phase_stop_5 >= phase_start_6
+                    for i_11 = phase_start_6:phase_stop_5
+                        if res_lvl_qos > res_lvl_qos_stop
+                            res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_val, res_lvl_qos_stop)
+                            Finch.fill_range!(res_lvl_val, false, res_lvl_qos, res_lvl_qos_stop)
+                        end
+                        tmp_lvl_q = tmp_lvl_q_ofs + i_11
+                        tmp_lvl_2_val_2 = tmp_lvl_val[tmp_lvl_q]
+                        res_lvl_val[res_lvl_qos] = tmp_lvl_2_val_2
+                        res_lvl_idx[res_lvl_qos] = i_11
+                        res_lvl_qos += 1
+                    end
+                end
+                tmp_lvl_r += phase_stop_5 == tmp_lvl_i
+                i = phase_stop_5 + 1
+                break
             end
-            tmp_lvl_r += phase_stop_2 == tmp_lvl_i
-            i = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(Dense(SparseByteMap(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(Dense(SparseByteMap(Element(false)))).jl
@@ -40,14 +40,12 @@ begin
         end
         phase_stop = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape)
         if phase_stop >= 1
-            i = 1
             while tmp_lvl_2_r + 1 < tmp_lvl_2_r_stop && last(tmp_lvl_srt[tmp_lvl_2_r]) < 1
                 tmp_lvl_2_r += 1
             end
-            while i <= phase_stop
+            while true
                 tmp_lvl_2_i = last(tmp_lvl_srt[tmp_lvl_2_r])
-                phase_stop_2 = min(phase_stop, tmp_lvl_2_i)
-                if tmp_lvl_2_i == phase_stop_2
+                if tmp_lvl_2_i < phase_stop
                     tmp_lvl_2_q = (tmp_lvl_q - 1) * tmp_lvl_2.shape + tmp_lvl_2_i
                     tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
                     if res_lvl_2_qos > res_lvl_2_qos_stop
@@ -58,12 +56,30 @@ begin
                     end
                     res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                     res_lvldirty = true
-                    res_lvl_idx_2[res_lvl_2_qos] = phase_stop_2
+                    res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                     res_lvl_2_qos += 1
                     res_lvl_2_prev_pos = res_lvl_qos
                     tmp_lvl_2_r += 1
+                else
+                    phase_stop_3 = min(tmp_lvl_2_i, phase_stop)
+                    if tmp_lvl_2_i == phase_stop_3
+                        tmp_lvl_2_q = (tmp_lvl_q - 1) * tmp_lvl_2.shape + tmp_lvl_2_i
+                        tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                        if res_lvl_2_qos > res_lvl_2_qos_stop
+                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        end
+                        res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                        res_lvldirty = true
+                        res_lvl_idx_2[res_lvl_2_qos] = phase_stop_3
+                        res_lvl_2_qos += 1
+                        res_lvl_2_prev_pos = res_lvl_qos
+                        tmp_lvl_2_r += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
         res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(Dense(SparseCOO{1}(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(Dense(SparseCOO{1}(Element(false)))).jl
@@ -40,14 +40,12 @@ begin
         end
         phase_stop = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape[1])
         if phase_stop >= 1
-            i = 1
             if tmp_lvl_tbl1[tmp_lvl_2_q] < 1
                 tmp_lvl_2_q = Finch.scansearch(tmp_lvl_tbl1, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 tmp_lvl_2_i = tmp_lvl_tbl1[tmp_lvl_2_q]
-                phase_stop_2 = min(phase_stop, tmp_lvl_2_i)
-                if tmp_lvl_2_i == phase_stop_2
+                if tmp_lvl_2_i < phase_stop
                     tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
                     if res_lvl_2_qos > res_lvl_2_qos_stop
                         res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -57,12 +55,29 @@ begin
                     end
                     res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                     res_lvldirty = true
-                    res_lvl_idx_2[res_lvl_2_qos] = phase_stop_2
+                    res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                     res_lvl_2_qos += 1
                     res_lvl_2_prev_pos = res_lvl_qos
                     tmp_lvl_2_q += 1
+                else
+                    phase_stop_3 = min(tmp_lvl_2_i, phase_stop)
+                    if tmp_lvl_2_i == phase_stop_3
+                        tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                        if res_lvl_2_qos > res_lvl_2_qos_stop
+                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        end
+                        res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                        res_lvldirty = true
+                        res_lvl_idx_2[res_lvl_2_qos] = phase_stop_3
+                        res_lvl_2_qos += 1
+                        res_lvl_2_prev_pos = res_lvl_qos
+                        tmp_lvl_2_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
         res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(Dense(SparseHash{1}(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(Dense(SparseHash{1}(Element(false)))).jl
@@ -40,14 +40,12 @@ begin
         end
         phase_stop = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape[1])
         if phase_stop >= 1
-            i = 1
             while tmp_lvl_2_q + 1 < tmp_lvl_2_q_stop && (((tmp_lvl_srt[tmp_lvl_2_q])[1])[2])[1] < 1
                 tmp_lvl_2_q += 1
             end
-            while i <= phase_stop
+            while true
                 tmp_lvl_2_i = (((tmp_lvl_srt[tmp_lvl_2_q])[1])[2])[1]
-                phase_stop_2 = min(phase_stop, tmp_lvl_2_i)
-                if tmp_lvl_2_i == phase_stop_2
+                if tmp_lvl_2_i < phase_stop
                     tmp_lvl_3_val = tmp_lvl_2_val[(tmp_lvl_2.srt[tmp_lvl_2_q])[2]]
                     if res_lvl_2_qos > res_lvl_2_qos_stop
                         res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -57,12 +55,29 @@ begin
                     end
                     res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                     res_lvldirty = true
-                    res_lvl_idx_2[res_lvl_2_qos] = phase_stop_2
+                    res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                     res_lvl_2_qos += 1
                     res_lvl_2_prev_pos = res_lvl_qos
                     tmp_lvl_2_q += 1
+                else
+                    phase_stop_3 = min(tmp_lvl_2_i, phase_stop)
+                    if tmp_lvl_2_i == phase_stop_3
+                        tmp_lvl_3_val = tmp_lvl_2_val[(tmp_lvl_2.srt[tmp_lvl_2_q])[2]]
+                        if res_lvl_2_qos > res_lvl_2_qos_stop
+                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        end
+                        res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                        res_lvldirty = true
+                        res_lvl_idx_2[res_lvl_2_qos] = phase_stop_3
+                        res_lvl_2_qos += 1
+                        res_lvl_2_prev_pos = res_lvl_qos
+                        tmp_lvl_2_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
         res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(Dense(SparseList(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(Dense(SparseList(Element(false)))).jl
@@ -40,14 +40,12 @@ begin
         end
         phase_stop = min(tmp_lvl_2_i1, tmp_lvl_2.shape)
         if phase_stop >= 1
-            i = 1
             if tmp_lvl_idx[tmp_lvl_2_q] < 1
                 tmp_lvl_2_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 tmp_lvl_2_i = tmp_lvl_idx[tmp_lvl_2_q]
-                phase_stop_2 = min(phase_stop, tmp_lvl_2_i)
-                if tmp_lvl_2_i == phase_stop_2
+                if tmp_lvl_2_i < phase_stop
                     tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
                     if res_lvl_2_qos > res_lvl_2_qos_stop
                         res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -57,12 +55,29 @@ begin
                     end
                     res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                     res_lvldirty = true
-                    res_lvl_idx_2[res_lvl_2_qos] = phase_stop_2
+                    res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                     res_lvl_2_qos += 1
                     res_lvl_2_prev_pos = res_lvl_qos
                     tmp_lvl_2_q += 1
+                else
+                    phase_stop_3 = min(tmp_lvl_2_i, phase_stop)
+                    if tmp_lvl_2_i == phase_stop_3
+                        tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                        if res_lvl_2_qos > res_lvl_2_qos_stop
+                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        end
+                        res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                        res_lvldirty = true
+                        res_lvl_idx_2[res_lvl_2_qos] = phase_stop_3
+                        res_lvl_2_qos += 1
+                        res_lvl_2_prev_pos = res_lvl_qos
+                        tmp_lvl_2_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
         res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(Dense(SparseRLE(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(Dense(SparseRLE(Element(false)))).jl
@@ -45,30 +45,54 @@ begin
             if tmp_lvl_right[tmp_lvl_2_q] < 1
                 tmp_lvl_2_q = Finch.scansearch(tmp_lvl_right, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
+                i_start_2 = i
                 tmp_lvl_2_i_start = tmp_lvl_left[tmp_lvl_2_q]
                 tmp_lvl_2_i_stop = tmp_lvl_right[tmp_lvl_2_q]
-                phase_start_2 = i
-                phase_stop_2 = min(phase_stop, tmp_lvl_2_i_stop)
-                phase_start_4 = max(phase_start_2, tmp_lvl_2_i_start)
-                if phase_stop_2 >= phase_start_4
-                    tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
-                    for i_8 = phase_start_4:phase_stop_2
-                        if res_lvl_2_qos > res_lvl_2_qos_stop
-                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
-                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
-                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
-                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                if tmp_lvl_2_i_stop < phase_stop
+                    phase_start_3 = max(i_start_2, tmp_lvl_2_i_start)
+                    if tmp_lvl_2_i_stop >= phase_start_3
+                        tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                        for i_8 = phase_start_3:tmp_lvl_2_i_stop
+                            if res_lvl_2_qos > res_lvl_2_qos_stop
+                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                            end
+                            res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                            res_lvldirty = true
+                            res_lvl_idx_2[res_lvl_2_qos] = i_8
+                            res_lvl_2_qos += 1
+                            res_lvl_2_prev_pos = res_lvl_qos
                         end
-                        res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
-                        res_lvldirty = true
-                        res_lvl_idx_2[res_lvl_2_qos] = i_8
-                        res_lvl_2_qos += 1
-                        res_lvl_2_prev_pos = res_lvl_qos
                     end
+                    tmp_lvl_2_q += tmp_lvl_2_i_stop == tmp_lvl_2_i_stop
+                    i = tmp_lvl_2_i_stop + 1
+                else
+                    phase_start_4 = i
+                    phase_stop_5 = min(tmp_lvl_2_i_stop, phase_stop)
+                    phase_start_6 = max(tmp_lvl_2_i_start, phase_start_4)
+                    if phase_stop_5 >= phase_start_6
+                        tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                        for i_11 = phase_start_6:phase_stop_5
+                            if res_lvl_2_qos > res_lvl_2_qos_stop
+                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                            end
+                            res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                            res_lvldirty = true
+                            res_lvl_idx_2[res_lvl_2_qos] = i_11
+                            res_lvl_2_qos += 1
+                            res_lvl_2_prev_pos = res_lvl_qos
+                        end
+                    end
+                    tmp_lvl_2_q += phase_stop_5 == tmp_lvl_2_i_stop
+                    i = phase_stop_5 + 1
+                    break
                 end
-                tmp_lvl_2_q += phase_stop_2 == tmp_lvl_2_i_stop
-                i = phase_stop_2 + 1
             end
         end
         res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(Dense(SparseVBL(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(Dense(SparseVBL(Element(false)))).jl
@@ -45,33 +45,58 @@ begin
             if tmp_lvl_idx[tmp_lvl_2_r] < 1
                 tmp_lvl_2_r = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_2_r, tmp_lvl_2_r_stop - 1)
             end
-            while i <= phase_stop
+            while true
+                i_start_2 = i
                 tmp_lvl_2_i = tmp_lvl_idx[tmp_lvl_2_r]
                 tmp_lvl_2_q_stop = tmp_lvl_ofs[tmp_lvl_2_r + 1]
                 tmp_lvl_2_i_2 = tmp_lvl_2_i - (tmp_lvl_2_q_stop - tmp_lvl_ofs[tmp_lvl_2_r])
                 tmp_lvl_2_q_ofs = (tmp_lvl_2_q_stop - tmp_lvl_2_i) - 1
-                phase_start_2 = i
-                phase_stop_2 = min(phase_stop, tmp_lvl_2_i)
-                phase_start_4 = max(phase_start_2, 1 + tmp_lvl_2_i_2)
-                if phase_stop_2 >= phase_start_4
-                    for i_8 = phase_start_4:phase_stop_2
-                        if res_lvl_2_qos > res_lvl_2_qos_stop
-                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
-                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
-                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
-                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                if tmp_lvl_2_i < phase_stop
+                    phase_start_3 = max(i_start_2, 1 + tmp_lvl_2_i_2)
+                    if tmp_lvl_2_i >= phase_start_3
+                        for i_8 = phase_start_3:tmp_lvl_2_i
+                            if res_lvl_2_qos > res_lvl_2_qos_stop
+                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                            end
+                            tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_8
+                            tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                            res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                            res_lvldirty = true
+                            res_lvl_idx_2[res_lvl_2_qos] = i_8
+                            res_lvl_2_qos += 1
+                            res_lvl_2_prev_pos = res_lvl_qos
                         end
-                        tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_8
-                        tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
-                        res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
-                        res_lvldirty = true
-                        res_lvl_idx_2[res_lvl_2_qos] = i_8
-                        res_lvl_2_qos += 1
-                        res_lvl_2_prev_pos = res_lvl_qos
                     end
+                    tmp_lvl_2_r += tmp_lvl_2_i == tmp_lvl_2_i
+                    i = tmp_lvl_2_i + 1
+                else
+                    phase_start_4 = i
+                    phase_stop_5 = min(tmp_lvl_2_i, phase_stop)
+                    phase_start_6 = max(1 + tmp_lvl_2_i_2, phase_start_4)
+                    if phase_stop_5 >= phase_start_6
+                        for i_11 = phase_start_6:phase_stop_5
+                            if res_lvl_2_qos > res_lvl_2_qos_stop
+                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                            end
+                            tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_11
+                            tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                            res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                            res_lvldirty = true
+                            res_lvl_idx_2[res_lvl_2_qos] = i_11
+                            res_lvl_2_qos += 1
+                            res_lvl_2_prev_pos = res_lvl_qos
+                        end
+                    end
+                    tmp_lvl_2_r += phase_stop_5 == tmp_lvl_2_i
+                    i = phase_stop_5 + 1
+                    break
                 end
-                tmp_lvl_2_r += phase_stop_2 == tmp_lvl_2_i
-                i = phase_stop_2 + 1
             end
         end
         res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseCOO{2}(Element(false))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseCOO{2}(Element(false))).jl
@@ -29,18 +29,16 @@ begin
     end
     phase_stop = min(tmp_lvl_i_stop, tmp_lvl.shape[2])
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_tbl2[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_tbl2, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_tbl2[tmp_lvl_q]
             tmp_lvl_q_step = tmp_lvl_q
             if tmp_lvl_tbl2[tmp_lvl_q] == tmp_lvl_i
                 tmp_lvl_q_step = Finch.scansearch(tmp_lvl_tbl2, tmp_lvl_i + 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
             end
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -58,14 +56,12 @@ begin
                 end
                 phase_stop_3 = min(tmp_lvl_i_stop_2, tmp_lvl.shape[1])
                 if phase_stop_3 >= 1
-                    i = 1
                     if tmp_lvl_tbl1[tmp_lvl_q] < 1
                         tmp_lvl_q_2 = Finch.scansearch(tmp_lvl_tbl1, 1, tmp_lvl_q, tmp_lvl_q_step - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         tmp_lvl_i_2 = tmp_lvl_tbl1[tmp_lvl_q_2]
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_i_2)
-                        if tmp_lvl_i_2 == phase_stop_4
+                        if tmp_lvl_i_2 < phase_stop_3
                             tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q_2]
                             if res_lvl_2_qos > res_lvl_2_qos_stop
                                 res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -75,23 +71,108 @@ begin
                             end
                             res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_2_val)
                             res_lvldirty = true
-                            res_lvl_idx_2[res_lvl_2_qos] = phase_stop_4
+                            res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_i_2
                             res_lvl_2_qos += 1
                             res_lvl_2_prev_pos = res_lvl_qos
                             tmp_lvl_q_2 += 1
+                        else
+                            phase_stop_5 = min(tmp_lvl_i_2, phase_stop_3)
+                            if tmp_lvl_i_2 == phase_stop_5
+                                tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q_2]
+                                if res_lvl_2_qos > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_2_val
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos] = phase_stop_5
+                                res_lvl_2_qos += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_q_2 += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q = tmp_lvl_q_step
+            else
+                phase_stop_7 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_7
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_q_2 = tmp_lvl_q
+                    if tmp_lvl_q < tmp_lvl_q_step
+                        tmp_lvl_i_stop_2 = tmp_lvl_tbl1[tmp_lvl_q_step - 1]
+                    else
+                        tmp_lvl_i_stop_2 = 0
+                    end
+                    phase_stop_8 = min(tmp_lvl_i_stop_2, tmp_lvl.shape[1])
+                    if phase_stop_8 >= 1
+                        if tmp_lvl_tbl1[tmp_lvl_q] < 1
+                            tmp_lvl_q_2 = Finch.scansearch(tmp_lvl_tbl1, 1, tmp_lvl_q, tmp_lvl_q_step - 1)
+                        end
+                        while true
+                            tmp_lvl_i_2 = tmp_lvl_tbl1[tmp_lvl_q_2]
+                            if tmp_lvl_i_2 < phase_stop_8
+                                tmp_lvl_2_val_2 = tmp_lvl_val[tmp_lvl_q_2]
+                                if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_2_val_2
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos_2] = tmp_lvl_i_2
+                                res_lvl_2_qos_2 += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_q_2 += 1
+                            else
+                                phase_stop_10 = min(tmp_lvl_i_2, phase_stop_8)
+                                if tmp_lvl_i_2 == phase_stop_10
+                                    tmp_lvl_2_val_2 = tmp_lvl_val[tmp_lvl_q_2]
+                                    if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_2_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos_2] = phase_stop_10
+                                    res_lvl_2_qos_2 += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_q_2 += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_7
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q = tmp_lvl_q_step
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseHash{2}(Element(false))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseHash{2}(Element(false))).jl
@@ -28,18 +28,16 @@ begin
     end
     phase_stop = min(tmp_lvl_i_stop, tmp_lvl.shape[2])
     if phase_stop >= 1
-        j = 1
         while tmp_lvl_q + 1 < tmp_lvl_q_stop && (((tmp_lvl_srt[tmp_lvl_q])[1])[2])[2] < 1
             tmp_lvl_q += 1
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = (((tmp_lvl_srt[tmp_lvl_q])[1])[2])[2]
             tmp_lvl_q_step = tmp_lvl_q
             while tmp_lvl_q_step < tmp_lvl_q_stop && (((tmp_lvl_srt[tmp_lvl_q_step])[1])[2])[2] == tmp_lvl_i
                 tmp_lvl_q_step += 1
             end
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -57,14 +55,12 @@ begin
                 end
                 phase_stop_3 = min(tmp_lvl_i_stop_2, tmp_lvl.shape[1])
                 if phase_stop_3 >= 1
-                    i = 1
                     while tmp_lvl_q_2 + 1 < tmp_lvl_q_step && (((tmp_lvl_srt[tmp_lvl_q_2])[1])[2])[1] < 1
                         tmp_lvl_q_2 += 1
                     end
-                    while i <= phase_stop_3
+                    while true
                         tmp_lvl_i_2 = (((tmp_lvl_srt[tmp_lvl_q_2])[1])[2])[1]
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_i_2)
-                        if tmp_lvl_i_2 == phase_stop_4
+                        if tmp_lvl_i_2 < phase_stop_3
                             tmp_lvl_2_val = tmp_lvl_val[(tmp_lvl.srt[tmp_lvl_q_2])[2]]
                             if res_lvl_2_qos > res_lvl_2_qos_stop
                                 res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -74,23 +70,108 @@ begin
                             end
                             res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_2_val)
                             res_lvldirty = true
-                            res_lvl_idx_2[res_lvl_2_qos] = phase_stop_4
+                            res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_i_2
                             res_lvl_2_qos += 1
                             res_lvl_2_prev_pos = res_lvl_qos
                             tmp_lvl_q_2 += 1
+                        else
+                            phase_stop_5 = min(tmp_lvl_i_2, phase_stop_3)
+                            if tmp_lvl_i_2 == phase_stop_5
+                                tmp_lvl_2_val = tmp_lvl_val[(tmp_lvl.srt[tmp_lvl_q_2])[2]]
+                                if res_lvl_2_qos > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_2_val
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos] = phase_stop_5
+                                res_lvl_2_qos += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_q_2 += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q = tmp_lvl_q_step
+            else
+                phase_stop_7 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_7
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_q_2 = tmp_lvl_q
+                    if tmp_lvl_q < tmp_lvl_q_step
+                        tmp_lvl_i_stop_2 = (((tmp_lvl_srt[tmp_lvl_q_step - 1])[1])[2])[1]
+                    else
+                        tmp_lvl_i_stop_2 = 0
+                    end
+                    phase_stop_8 = min(tmp_lvl_i_stop_2, tmp_lvl.shape[1])
+                    if phase_stop_8 >= 1
+                        while tmp_lvl_q_2 + 1 < tmp_lvl_q_step && (((tmp_lvl_srt[tmp_lvl_q_2])[1])[2])[1] < 1
+                            tmp_lvl_q_2 += 1
+                        end
+                        while true
+                            tmp_lvl_i_2 = (((tmp_lvl_srt[tmp_lvl_q_2])[1])[2])[1]
+                            if tmp_lvl_i_2 < phase_stop_8
+                                tmp_lvl_2_val_2 = tmp_lvl_val[(tmp_lvl.srt[tmp_lvl_q_2])[2]]
+                                if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_2_val_2
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos_2] = tmp_lvl_i_2
+                                res_lvl_2_qos_2 += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_q_2 += 1
+                            else
+                                phase_stop_10 = min(tmp_lvl_i_2, phase_stop_8)
+                                if tmp_lvl_i_2 == phase_stop_10
+                                    tmp_lvl_2_val_2 = tmp_lvl_val[(tmp_lvl.srt[tmp_lvl_q_2])[2]]
+                                    if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_2_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos_2] = phase_stop_10
+                                    res_lvl_2_qos_2 += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_q_2 += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_7
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q = tmp_lvl_q_step
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseByteMap(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseByteMap(Element(false)))).jl
@@ -31,14 +31,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -57,14 +55,12 @@ begin
                 end
                 phase_stop_3 = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     while tmp_lvl_2_r + 1 < tmp_lvl_2_r_stop && last(tmp_lvl_srt[tmp_lvl_2_r]) < 1
                         tmp_lvl_2_r += 1
                     end
-                    while i <= phase_stop_3
+                    while true
                         tmp_lvl_2_i = last(tmp_lvl_srt[tmp_lvl_2_r])
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_2_i)
-                        if tmp_lvl_2_i == phase_stop_4
+                        if tmp_lvl_2_i < phase_stop_3
                             tmp_lvl_2_q = (tmp_lvl_q - 1) * tmp_lvl_2.shape + tmp_lvl_2_i
                             tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
                             if res_lvl_2_qos > res_lvl_2_qos_stop
@@ -75,23 +71,112 @@ begin
                             end
                             res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                             res_lvldirty = true
-                            res_lvl_idx_2[res_lvl_2_qos] = phase_stop_4
+                            res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                             res_lvl_2_qos += 1
                             res_lvl_2_prev_pos = res_lvl_qos
                             tmp_lvl_2_r += 1
+                        else
+                            phase_stop_5 = min(tmp_lvl_2_i, phase_stop_3)
+                            if tmp_lvl_2_i == phase_stop_5
+                                tmp_lvl_2_q = (tmp_lvl_q - 1) * tmp_lvl_2.shape + tmp_lvl_2_i
+                                tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                if res_lvl_2_qos > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos] = phase_stop_5
+                                res_lvl_2_qos += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_r += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_7 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_7
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_2_r = tmp_lvl_ptr_2[tmp_lvl_q]
+                    tmp_lvl_2_r_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                    if tmp_lvl_2_r != 0 && tmp_lvl_2_r < tmp_lvl_2_r_stop
+                        tmp_lvl_2_i_stop = last(tmp_lvl_srt[tmp_lvl_2_r_stop - 1])
+                    else
+                        tmp_lvl_2_i_stop = 0
+                    end
+                    phase_stop_8 = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        while tmp_lvl_2_r + 1 < tmp_lvl_2_r_stop && last(tmp_lvl_srt[tmp_lvl_2_r]) < 1
+                            tmp_lvl_2_r += 1
+                        end
+                        while true
+                            tmp_lvl_2_i = last(tmp_lvl_srt[tmp_lvl_2_r])
+                            if tmp_lvl_2_i < phase_stop_8
+                                tmp_lvl_2_q = (tmp_lvl_q - 1) * tmp_lvl_2.shape + tmp_lvl_2_i
+                                tmp_lvl_3_val_3 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_3
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos_2] = tmp_lvl_2_i
+                                res_lvl_2_qos_2 += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_r += 1
+                            else
+                                phase_stop_10 = min(tmp_lvl_2_i, phase_stop_8)
+                                if tmp_lvl_2_i == phase_stop_10
+                                    tmp_lvl_2_q = (tmp_lvl_q - 1) * tmp_lvl_2.shape + tmp_lvl_2_i
+                                    tmp_lvl_3_val_4 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_4
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos_2] = phase_stop_10
+                                    res_lvl_2_qos_2 += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_2_r += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_7
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseCOO{1}(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseCOO{1}(Element(false)))).jl
@@ -31,14 +31,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -57,14 +55,12 @@ begin
                 end
                 phase_stop_3 = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape[1])
                 if phase_stop_3 >= 1
-                    i = 1
                     if tmp_lvl_tbl1[tmp_lvl_2_q] < 1
                         tmp_lvl_2_q = Finch.scansearch(tmp_lvl_tbl1, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         tmp_lvl_2_i = tmp_lvl_tbl1[tmp_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_2_i)
-                        if tmp_lvl_2_i == phase_stop_4
+                        if tmp_lvl_2_i < phase_stop_3
                             tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
                             if res_lvl_2_qos > res_lvl_2_qos_stop
                                 res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -74,23 +70,109 @@ begin
                             end
                             res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                             res_lvldirty = true
-                            res_lvl_idx_2[res_lvl_2_qos] = phase_stop_4
+                            res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                             res_lvl_2_qos += 1
                             res_lvl_2_prev_pos = res_lvl_qos
                             tmp_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(tmp_lvl_2_i, phase_stop_3)
+                            if tmp_lvl_2_i == phase_stop_5
+                                tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                                if res_lvl_2_qos > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos] = phase_stop_5
+                                res_lvl_2_qos += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_7 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_7
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_2_q = tmp_lvl_ptr_2[tmp_lvl_q]
+                    tmp_lvl_2_q_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                    if tmp_lvl_2_q < tmp_lvl_2_q_stop
+                        tmp_lvl_2_i_stop = tmp_lvl_tbl1[tmp_lvl_2_q_stop - 1]
+                    else
+                        tmp_lvl_2_i_stop = 0
+                    end
+                    phase_stop_8 = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape[1])
+                    if phase_stop_8 >= 1
+                        if tmp_lvl_tbl1[tmp_lvl_2_q] < 1
+                            tmp_lvl_2_q = Finch.scansearch(tmp_lvl_tbl1, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            tmp_lvl_2_i = tmp_lvl_tbl1[tmp_lvl_2_q]
+                            if tmp_lvl_2_i < phase_stop_8
+                                tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos_2] = tmp_lvl_2_i
+                                res_lvl_2_qos_2 += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(tmp_lvl_2_i, phase_stop_8)
+                                if tmp_lvl_2_i == phase_stop_10
+                                    tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos_2] = phase_stop_10
+                                    res_lvl_2_qos_2 += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_7
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseHash{1}(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseHash{1}(Element(false)))).jl
@@ -31,14 +31,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -57,14 +55,12 @@ begin
                 end
                 phase_stop_3 = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape[1])
                 if phase_stop_3 >= 1
-                    i = 1
                     while tmp_lvl_2_q + 1 < tmp_lvl_2_q_stop && (((tmp_lvl_srt[tmp_lvl_2_q])[1])[2])[1] < 1
                         tmp_lvl_2_q += 1
                     end
-                    while i <= phase_stop_3
+                    while true
                         tmp_lvl_2_i = (((tmp_lvl_srt[tmp_lvl_2_q])[1])[2])[1]
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_2_i)
-                        if tmp_lvl_2_i == phase_stop_4
+                        if tmp_lvl_2_i < phase_stop_3
                             tmp_lvl_3_val = tmp_lvl_2_val[(tmp_lvl_2.srt[tmp_lvl_2_q])[2]]
                             if res_lvl_2_qos > res_lvl_2_qos_stop
                                 res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -74,23 +70,109 @@ begin
                             end
                             res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                             res_lvldirty = true
-                            res_lvl_idx_2[res_lvl_2_qos] = phase_stop_4
+                            res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                             res_lvl_2_qos += 1
                             res_lvl_2_prev_pos = res_lvl_qos
                             tmp_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(tmp_lvl_2_i, phase_stop_3)
+                            if tmp_lvl_2_i == phase_stop_5
+                                tmp_lvl_3_val = tmp_lvl_2_val[(tmp_lvl_2.srt[tmp_lvl_2_q])[2]]
+                                if res_lvl_2_qos > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos] = phase_stop_5
+                                res_lvl_2_qos += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_7 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_7
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_2_q = tmp_lvl_ptr_2[tmp_lvl_q]
+                    tmp_lvl_2_q_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                    if tmp_lvl_2_q < tmp_lvl_2_q_stop
+                        tmp_lvl_2_i_stop = (((tmp_lvl_srt[tmp_lvl_2_q_stop - 1])[1])[2])[1]
+                    else
+                        tmp_lvl_2_i_stop = 0
+                    end
+                    phase_stop_8 = min(tmp_lvl_2_i_stop, tmp_lvl_2.shape[1])
+                    if phase_stop_8 >= 1
+                        while tmp_lvl_2_q + 1 < tmp_lvl_2_q_stop && (((tmp_lvl_srt[tmp_lvl_2_q])[1])[2])[1] < 1
+                            tmp_lvl_2_q += 1
+                        end
+                        while true
+                            tmp_lvl_2_i = (((tmp_lvl_srt[tmp_lvl_2_q])[1])[2])[1]
+                            if tmp_lvl_2_i < phase_stop_8
+                                tmp_lvl_3_val_2 = tmp_lvl_2_val[(tmp_lvl_2.srt[tmp_lvl_2_q])[2]]
+                                if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos_2] = tmp_lvl_2_i
+                                res_lvl_2_qos_2 += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(tmp_lvl_2_i, phase_stop_8)
+                                if tmp_lvl_2_i == phase_stop_10
+                                    tmp_lvl_3_val_2 = tmp_lvl_2_val[(tmp_lvl_2.srt[tmp_lvl_2_q])[2]]
+                                    if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos_2] = phase_stop_10
+                                    res_lvl_2_qos_2 += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_7
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseList(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseList(Element(false)))).jl
@@ -31,14 +31,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -57,14 +55,12 @@ begin
                 end
                 phase_stop_3 = min(tmp_lvl_2_i1, tmp_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if tmp_lvl_idx_2[tmp_lvl_2_q] < 1
                         tmp_lvl_2_q = Finch.scansearch(tmp_lvl_idx_2, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         tmp_lvl_2_i = tmp_lvl_idx_2[tmp_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_2_i)
-                        if tmp_lvl_2_i == phase_stop_4
+                        if tmp_lvl_2_i < phase_stop_3
                             tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
                             if res_lvl_2_qos > res_lvl_2_qos_stop
                                 res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
@@ -74,23 +70,109 @@ begin
                             end
                             res = (res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val)
                             res_lvldirty = true
-                            res_lvl_idx_2[res_lvl_2_qos] = phase_stop_4
+                            res_lvl_idx_2[res_lvl_2_qos] = tmp_lvl_2_i
                             res_lvl_2_qos += 1
                             res_lvl_2_prev_pos = res_lvl_qos
                             tmp_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(tmp_lvl_2_i, phase_stop_3)
+                            if tmp_lvl_2_i == phase_stop_5
+                                tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                                if res_lvl_2_qos > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos] = phase_stop_5
+                                res_lvl_2_qos += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_7 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_7
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_2_q = tmp_lvl_ptr_2[tmp_lvl_q]
+                    tmp_lvl_2_q_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                    if tmp_lvl_2_q < tmp_lvl_2_q_stop
+                        tmp_lvl_2_i1 = tmp_lvl_idx_2[tmp_lvl_2_q_stop - 1]
+                    else
+                        tmp_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(tmp_lvl_2_i1, tmp_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if tmp_lvl_idx_2[tmp_lvl_2_q] < 1
+                            tmp_lvl_2_q = Finch.scansearch(tmp_lvl_idx_2, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            tmp_lvl_2_i = tmp_lvl_idx_2[tmp_lvl_2_q]
+                            if tmp_lvl_2_i < phase_stop_8
+                                tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                end
+                                res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                                res_lvldirty = true
+                                res_lvl_idx_2[res_lvl_2_qos_2] = tmp_lvl_2_i
+                                res_lvl_2_qos_2 += 1
+                                res_lvl_2_prev_pos = res_lvl_qos
+                                tmp_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(tmp_lvl_2_i, phase_stop_8)
+                                if tmp_lvl_2_i == phase_stop_10
+                                    tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos_2] = phase_stop_10
+                                    res_lvl_2_qos_2 += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_7
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseRLE(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseRLE(Element(false)))).jl
@@ -32,14 +32,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -62,41 +60,148 @@ begin
                     if tmp_lvl_right[tmp_lvl_2_q] < 1
                         tmp_lvl_2_q = Finch.scansearch(tmp_lvl_right, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
+                        i_start_2 = i
                         tmp_lvl_2_i_start = tmp_lvl_left[tmp_lvl_2_q]
                         tmp_lvl_2_i_stop = tmp_lvl_right[tmp_lvl_2_q]
-                        phase_start_4 = i
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_2_i_stop)
-                        phase_start_6 = max(phase_start_4, tmp_lvl_2_i_start)
-                        if phase_stop_4 >= phase_start_6
-                            tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
-                            for i_8 = phase_start_6:phase_stop_4
-                                if res_lvl_2_qos > res_lvl_2_qos_stop
-                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
-                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
-                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
-                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        if tmp_lvl_2_i_stop < phase_stop_3
+                            phase_start_4 = max(i_start_2, tmp_lvl_2_i_start)
+                            if tmp_lvl_2_i_stop >= phase_start_4
+                                tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                                for i_8 = phase_start_4:tmp_lvl_2_i_stop
+                                    if res_lvl_2_qos > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos] = i_8
+                                    res_lvl_2_qos += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
                                 end
-                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
-                                res_lvldirty = true
-                                res_lvl_idx_2[res_lvl_2_qos] = i_8
-                                res_lvl_2_qos += 1
-                                res_lvl_2_prev_pos = res_lvl_qos
                             end
+                            tmp_lvl_2_q += tmp_lvl_2_i_stop == tmp_lvl_2_i_stop
+                            i = tmp_lvl_2_i_stop + 1
+                        else
+                            phase_start_5 = i
+                            phase_stop_7 = min(tmp_lvl_2_i_stop, phase_stop_3)
+                            phase_start_7 = max(tmp_lvl_2_i_start, phase_start_5)
+                            if phase_stop_7 >= phase_start_7
+                                tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                for i_11 = phase_start_7:phase_stop_7
+                                    if res_lvl_2_qos > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                    end
+                                    res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos] = i_11
+                                    res_lvl_2_qos += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                end
+                            end
+                            tmp_lvl_2_q += phase_stop_7 == tmp_lvl_2_i_stop
+                            i = phase_stop_7 + 1
+                            break
                         end
-                        tmp_lvl_2_q += phase_stop_4 == tmp_lvl_2_i_stop
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_11 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_11
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_2_q = tmp_lvl_ptr_2[tmp_lvl_q]
+                    tmp_lvl_2_q_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                    if tmp_lvl_2_q < tmp_lvl_2_q_stop
+                        tmp_lvl_2_i_end = tmp_lvl_right[tmp_lvl_2_q_stop - 1]
+                    else
+                        tmp_lvl_2_i_end = 0
+                    end
+                    phase_stop_12 = min(tmp_lvl_2_i_end, tmp_lvl_2.shape)
+                    if phase_stop_12 >= 1
+                        i = 1
+                        if tmp_lvl_right[tmp_lvl_2_q] < 1
+                            tmp_lvl_2_q = Finch.scansearch(tmp_lvl_right, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            i_start_6 = i
+                            tmp_lvl_2_i_start = tmp_lvl_left[tmp_lvl_2_q]
+                            tmp_lvl_2_i_stop = tmp_lvl_right[tmp_lvl_2_q]
+                            if tmp_lvl_2_i_stop < phase_stop_12
+                                phase_start_12 = max(tmp_lvl_2_i_start, i_start_6)
+                                if tmp_lvl_2_i_stop >= phase_start_12
+                                    tmp_lvl_3_val_3 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    for i_17 = phase_start_12:tmp_lvl_2_i_stop
+                                        if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                        end
+                                        res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_3
+                                        res_lvldirty = true
+                                        res_lvl_idx_2[res_lvl_2_qos_2] = i_17
+                                        res_lvl_2_qos_2 += 1
+                                        res_lvl_2_prev_pos = res_lvl_qos
+                                    end
+                                end
+                                tmp_lvl_2_q += tmp_lvl_2_i_stop == tmp_lvl_2_i_stop
+                                i = tmp_lvl_2_i_stop + 1
+                            else
+                                phase_start_13 = i
+                                phase_stop_16 = min(tmp_lvl_2_i_stop, phase_stop_12)
+                                phase_start_15 = max(tmp_lvl_2_i_start, phase_start_13)
+                                if phase_stop_16 >= phase_start_15
+                                    tmp_lvl_3_val_4 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    for i_20 = phase_start_15:phase_stop_16
+                                        if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                        end
+                                        res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_4
+                                        res_lvldirty = true
+                                        res_lvl_idx_2[res_lvl_2_qos_2] = i_20
+                                        res_lvl_2_qos_2 += 1
+                                        res_lvl_2_prev_pos = res_lvl_qos
+                                    end
+                                end
+                                tmp_lvl_2_q += phase_stop_16 == tmp_lvl_2_i_stop
+                                i = phase_stop_16 + 1
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_11
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseTriangle{1}(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseTriangle{1}(Element(false)))).jl
@@ -29,14 +29,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 tmp_lvl_2_q = (tmp_lvl_q - 1) * fld(tmp_lvl_2.shape, 1) + 1
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
@@ -67,12 +65,50 @@ begin
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_5 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_5
+                    tmp_lvl_2_q = (tmp_lvl_q - 1) * fld(tmp_lvl_2.shape, 1) + 1
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    phase_stop_6 = tmp_lvl_2.shape
+                    if phase_stop_6 >= 1
+                        for i_8 = 1:phase_stop_6
+                            if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                            end
+                            tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q + -1 + i_8]
+                            res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_2
+                            res_lvldirty = true
+                            res_lvl_idx_2[res_lvl_2_qos_2] = i_8
+                            res_lvl_2_qos_2 += 1
+                            res_lvl_2_prev_pos = res_lvl_qos
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_5
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseVBL(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseList(SparseVBL(Element(false)))).jl
@@ -32,14 +32,12 @@ begin
     end
     phase_stop = min(tmp_lvl_i1, tmp_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if tmp_lvl_idx[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_idx, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             tmp_lvl_i = tmp_lvl_idx[tmp_lvl_q]
-            phase_stop_2 = min(phase_stop, tmp_lvl_i)
-            if tmp_lvl_i == phase_stop_2
+            if tmp_lvl_i < phase_stop
                 if res_lvl_qos > res_lvl_qos_stop
                     res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
@@ -62,44 +60,156 @@ begin
                     if tmp_lvl_idx_2[tmp_lvl_2_r] < 1
                         tmp_lvl_2_r = Finch.scansearch(tmp_lvl_idx_2, 1, tmp_lvl_2_r, tmp_lvl_2_r_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
+                        i_start_2 = i
                         tmp_lvl_2_i = tmp_lvl_idx_2[tmp_lvl_2_r]
                         tmp_lvl_2_q_stop = tmp_lvl_ofs[tmp_lvl_2_r + 1]
                         tmp_lvl_2_i_2 = tmp_lvl_2_i - (tmp_lvl_2_q_stop - tmp_lvl_ofs[tmp_lvl_2_r])
                         tmp_lvl_2_q_ofs = (tmp_lvl_2_q_stop - tmp_lvl_2_i) - 1
-                        phase_start_4 = i
-                        phase_stop_4 = min(phase_stop_3, tmp_lvl_2_i)
-                        phase_start_6 = max(phase_start_4, 1 + tmp_lvl_2_i_2)
-                        if phase_stop_4 >= phase_start_6
-                            for i_8 = phase_start_6:phase_stop_4
-                                if res_lvl_2_qos > res_lvl_2_qos_stop
-                                    res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
-                                    Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
-                                    Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
-                                    Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        if tmp_lvl_2_i < phase_stop_3
+                            phase_start_4 = max(i_start_2, 1 + tmp_lvl_2_i_2)
+                            if tmp_lvl_2_i >= phase_start_4
+                                for i_8 = phase_start_4:tmp_lvl_2_i
+                                    if res_lvl_2_qos > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_8
+                                    tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos] = i_8
+                                    res_lvl_2_qos += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
                                 end
-                                tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_8
-                                tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
-                                res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
-                                res_lvldirty = true
-                                res_lvl_idx_2[res_lvl_2_qos] = i_8
-                                res_lvl_2_qos += 1
-                                res_lvl_2_prev_pos = res_lvl_qos
                             end
+                            tmp_lvl_2_r += tmp_lvl_2_i == tmp_lvl_2_i
+                            i = tmp_lvl_2_i + 1
+                        else
+                            phase_start_5 = i
+                            phase_stop_7 = min(tmp_lvl_2_i, phase_stop_3)
+                            phase_start_7 = max(1 + tmp_lvl_2_i_2, phase_start_5)
+                            if phase_stop_7 >= phase_start_7
+                                for i_11 = phase_start_7:phase_stop_7
+                                    if res_lvl_2_qos > res_lvl_2_qos_stop
+                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_11
+                                    tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                    res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                                    res_lvldirty = true
+                                    res_lvl_idx_2[res_lvl_2_qos] = i_11
+                                    res_lvl_2_qos += 1
+                                    res_lvl_2_prev_pos = res_lvl_qos
+                                end
+                            end
+                            tmp_lvl_2_r += phase_stop_7 == tmp_lvl_2_i
+                            i = phase_stop_7 + 1
+                            break
                         end
-                        tmp_lvl_2_r += phase_stop_4 == tmp_lvl_2_i
-                        i = phase_stop_4 + 1
                     end
                 end
                 res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
                 res_lvl_2_qos_fill = res_lvl_2_qos - 1
                 if res_lvldirty
-                    res_lvl_idx[res_lvl_qos] = phase_stop_2
+                    res_lvl_idx[res_lvl_qos] = tmp_lvl_i
                     res_lvl_qos += 1
                 end
                 tmp_lvl_q += 1
+            else
+                phase_stop_11 = min(tmp_lvl_i, phase_stop)
+                if tmp_lvl_i == phase_stop_11
+                    if res_lvl_qos > res_lvl_qos_stop
+                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                    end
+                    res_lvldirty = false
+                    res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    tmp_lvl_2_r = tmp_lvl_ptr_2[tmp_lvl_q]
+                    tmp_lvl_2_r_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                    if tmp_lvl_2_r < tmp_lvl_2_r_stop
+                        tmp_lvl_2_i1 = tmp_lvl_idx_2[tmp_lvl_2_r_stop - 1]
+                    else
+                        tmp_lvl_2_i1 = 0
+                    end
+                    phase_stop_12 = min(tmp_lvl_2_i1, tmp_lvl_2.shape)
+                    if phase_stop_12 >= 1
+                        i = 1
+                        if tmp_lvl_idx_2[tmp_lvl_2_r] < 1
+                            tmp_lvl_2_r = Finch.scansearch(tmp_lvl_idx_2, 1, tmp_lvl_2_r, tmp_lvl_2_r_stop - 1)
+                        end
+                        while true
+                            i_start_6 = i
+                            tmp_lvl_2_i = tmp_lvl_idx_2[tmp_lvl_2_r]
+                            tmp_lvl_2_q_stop = tmp_lvl_ofs[tmp_lvl_2_r + 1]
+                            tmp_lvl_2_i_2 = tmp_lvl_2_i - (tmp_lvl_2_q_stop - tmp_lvl_ofs[tmp_lvl_2_r])
+                            tmp_lvl_2_q_ofs = (tmp_lvl_2_q_stop - tmp_lvl_2_i) - 1
+                            if tmp_lvl_2_i < phase_stop_12
+                                phase_start_12 = max(1 + tmp_lvl_2_i_2, i_start_6)
+                                if tmp_lvl_2_i >= phase_start_12
+                                    for i_17 = phase_start_12:tmp_lvl_2_i
+                                        if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                        end
+                                        tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_17
+                                        tmp_lvl_3_val_3 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                        res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_3
+                                        res_lvldirty = true
+                                        res_lvl_idx_2[res_lvl_2_qos_2] = i_17
+                                        res_lvl_2_qos_2 += 1
+                                        res_lvl_2_prev_pos = res_lvl_qos
+                                    end
+                                end
+                                tmp_lvl_2_r += tmp_lvl_2_i == tmp_lvl_2_i
+                                i = tmp_lvl_2_i + 1
+                            else
+                                phase_start_13 = i
+                                phase_stop_16 = min(tmp_lvl_2_i, phase_stop_12)
+                                phase_start_15 = max(1 + tmp_lvl_2_i_2, phase_start_13)
+                                if phase_stop_16 >= phase_start_15
+                                    for i_20 = phase_start_15:phase_stop_16
+                                        if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                            res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                            Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                            Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                        end
+                                        tmp_lvl_2_q = tmp_lvl_2_q_ofs + i_20
+                                        tmp_lvl_3_val_4 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                        res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_4
+                                        res_lvldirty = true
+                                        res_lvl_idx_2[res_lvl_2_qos_2] = i_20
+                                        res_lvl_2_qos_2 += 1
+                                        res_lvl_2_prev_pos = res_lvl_qos
+                                    end
+                                end
+                                tmp_lvl_2_r += phase_stop_16 == tmp_lvl_2_i
+                                i = phase_stop_16 + 1
+                                break
+                            end
+                        end
+                    end
+                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                    res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                    if res_lvldirty
+                        res_lvl_idx[res_lvl_qos] = phase_stop_11
+                        res_lvl_qos += 1
+                    end
+                    tmp_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_from_0×0 Fiber!(SparseRLE(SparseRLE(Element(false)))).jl
+++ b/test/reference64/convert_from_0×0 Fiber!(SparseRLE(SparseRLE(Element(false)))).jl
@@ -37,72 +37,186 @@ begin
         if tmp_lvl_right[tmp_lvl_q] < 1
             tmp_lvl_q = Finch.scansearch(tmp_lvl_right, 1, tmp_lvl_q, tmp_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
+            j_start_2 = j
             tmp_lvl_i_start = tmp_lvl_left[tmp_lvl_q]
             tmp_lvl_i_stop = tmp_lvl_right[tmp_lvl_q]
-            phase_start_2 = j
-            phase_stop_2 = min(phase_stop, tmp_lvl_i_stop)
-            phase_start_4 = max(phase_start_2, tmp_lvl_i_start)
-            if phase_stop_2 >= phase_start_4
-                for j_8 = phase_start_4:phase_stop_2
-                    if res_lvl_qos > res_lvl_qos_stop
-                        res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
-                        Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
-                        Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
-                        Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
-                    end
-                    res_lvldirty = false
-                    res_lvl_2_qos = res_lvl_2_qos_fill + 1
-                    res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
-                    tmp_lvl_2_q = tmp_lvl_ptr_2[tmp_lvl_q]
-                    tmp_lvl_2_q_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
-                    if tmp_lvl_2_q < tmp_lvl_2_q_stop
-                        tmp_lvl_2_i_end = tmp_lvl_right_2[tmp_lvl_2_q_stop - 1]
-                    else
-                        tmp_lvl_2_i_end = 0
-                    end
-                    phase_stop_5 = min(tmp_lvl_2_i_end, tmp_lvl_2.shape)
-                    if phase_stop_5 >= 1
-                        i = 1
-                        if tmp_lvl_right_2[tmp_lvl_2_q] < 1
-                            tmp_lvl_2_q = Finch.scansearch(tmp_lvl_right_2, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
+            if tmp_lvl_i_stop < phase_stop
+                phase_start_3 = max(j_start_2, tmp_lvl_i_start)
+                if tmp_lvl_i_stop >= phase_start_3
+                    for j_8 = phase_start_3:tmp_lvl_i_stop
+                        if res_lvl_qos > res_lvl_qos_stop
+                            res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                            Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
                         end
-                        while i <= phase_stop_5
-                            tmp_lvl_2_i_start = tmp_lvl_left_2[tmp_lvl_2_q]
-                            tmp_lvl_2_i_stop = tmp_lvl_right_2[tmp_lvl_2_q]
-                            phase_start_6 = i
-                            phase_stop_6 = min(phase_stop_5, tmp_lvl_2_i_stop)
-                            phase_start_8 = max(phase_start_6, tmp_lvl_2_i_start)
-                            if phase_stop_6 >= phase_start_8
-                                tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
-                                for i_8 = phase_start_8:phase_stop_6
-                                    if res_lvl_2_qos > res_lvl_2_qos_stop
-                                        res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
-                                        Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
-                                        Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
-                                        Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                        res_lvldirty = false
+                        res_lvl_2_qos = res_lvl_2_qos_fill + 1
+                        res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                        tmp_lvl_2_q = tmp_lvl_ptr_2[tmp_lvl_q]
+                        tmp_lvl_2_q_stop = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                        if tmp_lvl_2_q < tmp_lvl_2_q_stop
+                            tmp_lvl_2_i_end = tmp_lvl_right_2[tmp_lvl_2_q_stop - 1]
+                        else
+                            tmp_lvl_2_i_end = 0
+                        end
+                        phase_stop_5 = min(tmp_lvl_2_i_end, tmp_lvl_2.shape)
+                        if phase_stop_5 >= 1
+                            i = 1
+                            if tmp_lvl_right_2[tmp_lvl_2_q] < 1
+                                tmp_lvl_2_q = Finch.scansearch(tmp_lvl_right_2, 1, tmp_lvl_2_q, tmp_lvl_2_q_stop - 1)
+                            end
+                            while true
+                                i_start_2 = i
+                                tmp_lvl_2_i_start = tmp_lvl_left_2[tmp_lvl_2_q]
+                                tmp_lvl_2_i_stop = tmp_lvl_right_2[tmp_lvl_2_q]
+                                if tmp_lvl_2_i_stop < phase_stop_5
+                                    phase_start_6 = max(i_start_2, tmp_lvl_2_i_start)
+                                    if tmp_lvl_2_i_stop >= phase_start_6
+                                        tmp_lvl_3_val = tmp_lvl_2_val[tmp_lvl_2_q]
+                                        for i_8 = phase_start_6:tmp_lvl_2_i_stop
+                                            if res_lvl_2_qos > res_lvl_2_qos_stop
+                                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                            end
+                                            res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
+                                            res_lvldirty = true
+                                            res_lvl_idx_2[res_lvl_2_qos] = i_8
+                                            res_lvl_2_qos += 1
+                                            res_lvl_2_prev_pos = res_lvl_qos
+                                        end
                                     end
-                                    res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val
-                                    res_lvldirty = true
-                                    res_lvl_idx_2[res_lvl_2_qos] = i_8
-                                    res_lvl_2_qos += 1
-                                    res_lvl_2_prev_pos = res_lvl_qos
+                                    tmp_lvl_2_q += tmp_lvl_2_i_stop == tmp_lvl_2_i_stop
+                                    i = tmp_lvl_2_i_stop + 1
+                                else
+                                    phase_start_7 = i
+                                    phase_stop_9 = min(tmp_lvl_2_i_stop, phase_stop_5)
+                                    phase_start_9 = max(tmp_lvl_2_i_start, phase_start_7)
+                                    if phase_stop_9 >= phase_start_9
+                                        tmp_lvl_3_val_2 = tmp_lvl_2_val[tmp_lvl_2_q]
+                                        for i_11 = phase_start_9:phase_stop_9
+                                            if res_lvl_2_qos > res_lvl_2_qos_stop
+                                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos, res_lvl_2_qos_stop)
+                                            end
+                                            res_lvl_2_val[res_lvl_2_qos] = tmp_lvl_3_val_2
+                                            res_lvldirty = true
+                                            res_lvl_idx_2[res_lvl_2_qos] = i_11
+                                            res_lvl_2_qos += 1
+                                            res_lvl_2_prev_pos = res_lvl_qos
+                                        end
+                                    end
+                                    tmp_lvl_2_q += phase_stop_9 == tmp_lvl_2_i_stop
+                                    i = phase_stop_9 + 1
+                                    break
                                 end
                             end
-                            tmp_lvl_2_q += phase_stop_6 == tmp_lvl_2_i_stop
-                            i = phase_stop_6 + 1
+                        end
+                        res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
+                        res_lvl_2_qos_fill = res_lvl_2_qos - 1
+                        if res_lvldirty
+                            res_lvl_idx[res_lvl_qos] = j_8
+                            res_lvl_qos += 1
                         end
                     end
-                    res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos - res_lvl_2_qos_fill) - 1
-                    res_lvl_2_qos_fill = res_lvl_2_qos - 1
-                    if res_lvldirty
-                        res_lvl_idx[res_lvl_qos] = j_8
-                        res_lvl_qos += 1
+                end
+                tmp_lvl_q += tmp_lvl_i_stop == tmp_lvl_i_stop
+                j = tmp_lvl_i_stop + 1
+            else
+                phase_start_11 = j
+                phase_stop_13 = min(tmp_lvl_i_stop, phase_stop)
+                phase_start_13 = max(tmp_lvl_i_start, phase_start_11)
+                if phase_stop_13 >= phase_start_13
+                    for j_11 = phase_start_13:phase_stop_13
+                        if res_lvl_qos > res_lvl_qos_stop
+                            res_lvl_qos_stop = max(res_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(res_lvl_idx, res_lvl_qos_stop)
+                            Finch.resize_if_smaller!(res_lvl_ptr_2, res_lvl_qos_stop + 1)
+                            Finch.fill_range!(res_lvl_ptr_2, 0, res_lvl_qos + 1, res_lvl_qos_stop + 1)
+                        end
+                        res_lvldirty = false
+                        res_lvl_2_qos_2 = res_lvl_2_qos_fill + 1
+                        res_lvl_2_prev_pos < res_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                        tmp_lvl_2_q_2 = tmp_lvl_ptr_2[tmp_lvl_q]
+                        tmp_lvl_2_q_stop_2 = tmp_lvl_ptr_2[tmp_lvl_q + 1]
+                        if tmp_lvl_2_q_2 < tmp_lvl_2_q_stop_2
+                            tmp_lvl_2_i_end_2 = tmp_lvl_right_2[tmp_lvl_2_q_stop_2 - 1]
+                        else
+                            tmp_lvl_2_i_end_2 = 0
+                        end
+                        phase_stop_16 = min(tmp_lvl_2.shape, tmp_lvl_2_i_end_2)
+                        if phase_stop_16 >= 1
+                            i = 1
+                            if tmp_lvl_right_2[tmp_lvl_2_q_2] < 1
+                                tmp_lvl_2_q_2 = Finch.scansearch(tmp_lvl_right_2, 1, tmp_lvl_2_q_2, tmp_lvl_2_q_stop_2 - 1)
+                            end
+                            while true
+                                i_start_6 = i
+                                tmp_lvl_2_i_start_2 = tmp_lvl_left_2[tmp_lvl_2_q_2]
+                                tmp_lvl_2_i_stop_2 = tmp_lvl_right_2[tmp_lvl_2_q_2]
+                                if tmp_lvl_2_i_stop_2 < phase_stop_16
+                                    phase_start_16 = max(i_start_6, tmp_lvl_2_i_start_2)
+                                    if tmp_lvl_2_i_stop_2 >= phase_start_16
+                                        tmp_lvl_3_val_3 = tmp_lvl_2_val[tmp_lvl_2_q_2]
+                                        for i_17 = phase_start_16:tmp_lvl_2_i_stop_2
+                                            if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                            end
+                                            res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_3
+                                            res_lvldirty = true
+                                            res_lvl_idx_2[res_lvl_2_qos_2] = i_17
+                                            res_lvl_2_qos_2 += 1
+                                            res_lvl_2_prev_pos = res_lvl_qos
+                                        end
+                                    end
+                                    tmp_lvl_2_q_2 += tmp_lvl_2_i_stop_2 == tmp_lvl_2_i_stop_2
+                                    i = tmp_lvl_2_i_stop_2 + 1
+                                else
+                                    phase_start_17 = i
+                                    phase_stop_20 = min(tmp_lvl_2_i_stop_2, phase_stop_16)
+                                    phase_start_19 = max(tmp_lvl_2_i_start_2, phase_start_17)
+                                    if phase_stop_20 >= phase_start_19
+                                        tmp_lvl_3_val_4 = tmp_lvl_2_val[tmp_lvl_2_q_2]
+                                        for i_20 = phase_start_19:phase_stop_20
+                                            if res_lvl_2_qos_2 > res_lvl_2_qos_stop
+                                                res_lvl_2_qos_stop = max(res_lvl_2_qos_stop << 1, 1)
+                                                Finch.resize_if_smaller!(res_lvl_idx_2, res_lvl_2_qos_stop)
+                                                Finch.resize_if_smaller!(res_lvl_2_val, res_lvl_2_qos_stop)
+                                                Finch.fill_range!(res_lvl_2_val, false, res_lvl_2_qos_2, res_lvl_2_qos_stop)
+                                            end
+                                            res_lvl_2_val[res_lvl_2_qos_2] = tmp_lvl_3_val_4
+                                            res_lvldirty = true
+                                            res_lvl_idx_2[res_lvl_2_qos_2] = i_20
+                                            res_lvl_2_qos_2 += 1
+                                            res_lvl_2_prev_pos = res_lvl_qos
+                                        end
+                                    end
+                                    tmp_lvl_2_q_2 += phase_stop_20 == tmp_lvl_2_i_stop_2
+                                    i = phase_stop_20 + 1
+                                    break
+                                end
+                            end
+                        end
+                        res_lvl_ptr_2[res_lvl_qos + 1] = (res_lvl_2_qos_2 - res_lvl_2_qos_fill) - 1
+                        res_lvl_2_qos_fill = res_lvl_2_qos_2 - 1
+                        if res_lvldirty
+                            res_lvl_idx[res_lvl_qos] = j_11
+                            res_lvl_qos += 1
+                        end
                     end
                 end
+                tmp_lvl_q += phase_stop_13 == tmp_lvl_i_stop
+                j = phase_stop_13 + 1
+                break
             end
-            tmp_lvl_q += phase_stop_2 == tmp_lvl_i_stop
-            j = phase_stop_2 + 1
         end
     end
     res_lvl_ptr[1 + 1] = (res_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0 Fiber!(SparseByteMap(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseByteMap(Element(false))).jl
@@ -39,16 +39,14 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
-                tmp_lvl_q_2 = (1 - 1) * ref_lvl.shape + phase_stop_2
+                tmp_lvl_q_2 = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 tmp_lvl_val[tmp_lvl_q_2] = ref_lvl_2_val
                 if !(tmp_lvl_tbl[tmp_lvl_q_2])
                     tmp_lvl_tbl[tmp_lvl_q_2] = true
@@ -57,11 +55,28 @@ begin
                         tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                         Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_qos_stop)
                     end
-                    tmp_lvl_srt[tmp_lvl_qos_fill] = (1, phase_stop_2)
+                    tmp_lvl_srt[tmp_lvl_qos_fill] = (1, ref_lvl_i)
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    tmp_lvl_q_2 = (1 - 1) * ref_lvl.shape + phase_stop_3
+                    tmp_lvl_val[tmp_lvl_q_2] = ref_lvl_2_val
+                    if !(tmp_lvl_tbl[tmp_lvl_q_2])
+                        tmp_lvl_tbl[tmp_lvl_q_2] = true
+                        tmp_lvl_qos_fill += 1
+                        if tmp_lvl_qos_fill > tmp_lvl_qos_stop
+                            tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_qos_stop)
+                        end
+                        tmp_lvl_srt[tmp_lvl_qos_fill] = (1, phase_stop_3)
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     sort!(view(tmp_lvl_srt, 1:tmp_lvl_qos_fill))

--- a/test/reference64/convert_to_0 Fiber!(SparseCOO{1}(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseCOO{1}(Element(false))).jl
@@ -23,14 +23,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
                 if tmp_lvl_q > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -39,13 +37,30 @@ begin
                     Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
                 end
                 tmp_lvl_val[tmp_lvl_q] = ref_lvl_2_val
-                tmp_lvl_prev_coord_2 < (phase_stop_2,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
-                tmp_lvl_prev_coord_2 = (phase_stop_2,)
-                tmp_lvl_tbl1[tmp_lvl_q] = phase_stop_2
+                tmp_lvl_prev_coord_2 < (ref_lvl_i,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                tmp_lvl_prev_coord_2 = (ref_lvl_i,)
+                tmp_lvl_tbl1[tmp_lvl_q] = ref_lvl_i
                 tmp_lvl_q += 1
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    if tmp_lvl_q > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
+                    end
+                    tmp_lvl_val[tmp_lvl_q] = ref_lvl_2_val
+                    tmp_lvl_prev_coord_2 < (phase_stop_3,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                    tmp_lvl_prev_coord_2 = (phase_stop_3,)
+                    tmp_lvl_tbl1[tmp_lvl_q] = phase_stop_3
+                    tmp_lvl_q += 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_q - 0) - 1

--- a/test/reference64/convert_to_0 Fiber!(SparseHash{1}(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseHash{1}(Element(false))).jl
@@ -24,16 +24,14 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
-                tmp_lvl_key = (1, (phase_stop_2,))
+                tmp_lvl_key = (1, (ref_lvl_i,))
                 tmp_lvl_q = get(tmp_lvl_tbl, tmp_lvl_key, tmp_lvl_qos_fill + 1)
                 if tmp_lvl_q > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -47,8 +45,27 @@ begin
                     tmp_lvl_ptr[1 + 1] += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    tmp_lvl_key = (1, (phase_stop_3,))
+                    tmp_lvl_q = get(tmp_lvl_tbl, tmp_lvl_key, tmp_lvl_qos_fill + 1)
+                    if tmp_lvl_q > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
+                    end
+                    tmp_lvl_val[tmp_lvl_q] = ref_lvl_2_val
+                    if tmp_lvl_q > tmp_lvl_qos_fill
+                        tmp_lvl_qos_fill = tmp_lvl_q
+                        tmp_lvl_tbl[tmp_lvl_key] = tmp_lvl_q
+                        tmp_lvl_ptr[1 + 1] += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     resize!(tmp_lvl_srt, length(tmp_lvl_tbl))

--- a/test/reference64/convert_to_0 Fiber!(SparseList(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseList(Element(false))).jl
@@ -22,14 +22,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -38,11 +36,26 @@ begin
                     Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_qos, tmp_lvl_qos_stop)
                 end
                 tmp_lvl_val[tmp_lvl_qos] = ref_lvl_2_val
-                tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                 tmp_lvl_qos += 1
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_qos, tmp_lvl_qos_stop)
+                    end
+                    tmp_lvl_val[tmp_lvl_qos] = ref_lvl_2_val
+                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_3
+                    tmp_lvl_qos += 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0 Fiber!(SparseRLE(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseRLE(Element(false))).jl
@@ -23,14 +23,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -40,12 +38,29 @@ begin
                     Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_qos, tmp_lvl_qos_stop)
                 end
                 tmp_lvl_val[tmp_lvl_qos] = ref_lvl_2_val
-                tmp_lvl_left[tmp_lvl_qos] = phase_stop_2
-                tmp_lvl_right[tmp_lvl_qos] = phase_stop_2
+                tmp_lvl_left[tmp_lvl_qos] = ref_lvl_i
+                tmp_lvl_right[tmp_lvl_qos] = ref_lvl_i
                 tmp_lvl_qos += 1
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_qos, tmp_lvl_qos_stop)
+                    end
+                    tmp_lvl_val[tmp_lvl_qos] = ref_lvl_2_val
+                    tmp_lvl_left[tmp_lvl_qos] = phase_stop_3
+                    tmp_lvl_right[tmp_lvl_qos] = phase_stop_3
+                    tmp_lvl_qos += 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0 Fiber!(SparseTriangle{1}(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseTriangle{1}(Element(false))).jl
@@ -19,19 +19,24 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
-                tmp_lvl_val[tmp_lvl_q + -1 + phase_stop_2] = ref_lvl_2_val
+                tmp_lvl_val[tmp_lvl_q + -1 + ref_lvl_i] = ref_lvl_2_val
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    tmp_lvl_val[tmp_lvl_q + -1 + phase_stop_3] = ref_lvl_2_val
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     resize!(tmp_lvl_val, 1 * fld(ref_lvl.shape, 1))

--- a/test/reference64/convert_to_0 Fiber!(SparseVBL(Element(false))).jl
+++ b/test/reference64/convert_to_0 Fiber!(SparseVBL(Element(false))).jl
@@ -28,14 +28,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -43,7 +41,7 @@ begin
                     Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_qos, tmp_lvl_qos_stop)
                 end
                 tmp_lvl_val[tmp_lvl_qos] = ref_lvl_2_val
-                if phase_stop_2 > tmp_lvl_i_prev + 1
+                if ref_lvl_i > tmp_lvl_i_prev + 1
                     tmp_lvl_ros += 1
                     if tmp_lvl_ros > tmp_lvl_ros_stop
                         tmp_lvl_ros_stop = max(tmp_lvl_ros_stop << 1, 1)
@@ -51,12 +49,35 @@ begin
                         Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_ros_stop + 1)
                     end
                 end
-                tmp_lvl_idx[tmp_lvl_ros] = (tmp_lvl_i_prev = phase_stop_2)
+                tmp_lvl_idx[tmp_lvl_ros] = (tmp_lvl_i_prev = ref_lvl_i)
                 tmp_lvl_qos += 1
                 tmp_lvl_ofs[tmp_lvl_ros + 1] = tmp_lvl_qos
                 ref_lvl_q += 1
+            else
+                phase_stop_3 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_3
+                    ref_lvl_2_val = ref_lvl_val[ref_lvl_q]
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_qos, tmp_lvl_qos_stop)
+                    end
+                    tmp_lvl_val[tmp_lvl_qos] = ref_lvl_2_val
+                    if phase_stop_3 > tmp_lvl_i_prev + 1
+                        tmp_lvl_ros += 1
+                        if tmp_lvl_ros > tmp_lvl_ros_stop
+                            tmp_lvl_ros_stop = max(tmp_lvl_ros_stop << 1, 1)
+                            Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_ros_stop)
+                            Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_ros_stop + 1)
+                        end
+                    end
+                    tmp_lvl_idx[tmp_lvl_ros] = (tmp_lvl_i_prev = phase_stop_3)
+                    tmp_lvl_qos += 1
+                    tmp_lvl_ofs[tmp_lvl_ros + 1] = tmp_lvl_qos
+                    ref_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = tmp_lvl_ros - 0

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseByteMap(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseByteMap(Element(false)))).jl
@@ -44,15 +44,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
                 ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
                 if ref_lvl_2_q < ref_lvl_2_q_stop
@@ -62,16 +60,14 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_2_q_2 = (tmp_lvl_q - 1) * ref_lvl_2.shape + phase_stop_4
+                            tmp_lvl_2_q_2 = (tmp_lvl_q - 1) * ref_lvl_2.shape + ref_lvl_2_i
                             tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val
                             if !(tmp_lvl_tbl[tmp_lvl_2_q_2])
                                 tmp_lvl_tbl[tmp_lvl_2_q_2] = true
@@ -80,16 +76,88 @@ begin
                                     tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
                                     Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
                                 end
-                                tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_q, phase_stop_4)
+                                tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_q, ref_lvl_2_i)
                             end
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_q_2 = (tmp_lvl_q - 1) * ref_lvl_2.shape + phase_stop_5
+                                tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val
+                                if !(tmp_lvl_tbl[tmp_lvl_2_q_2])
+                                    tmp_lvl_tbl[tmp_lvl_2_q_2] = true
+                                    tmp_lvl_2_qos_fill += 1
+                                    if tmp_lvl_2_qos_fill > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_q, phase_stop_5)
+                                end
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_7
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_q_3 = (tmp_lvl_q - 1) * ref_lvl_2.shape + ref_lvl_2_i
+                                tmp_lvl_2_val[tmp_lvl_2_q_3] = ref_lvl_3_val_2
+                                if !(tmp_lvl_tbl[tmp_lvl_2_q_3])
+                                    tmp_lvl_tbl[tmp_lvl_2_q_3] = true
+                                    tmp_lvl_2_qos_fill += 1
+                                    if tmp_lvl_2_qos_fill > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_q, ref_lvl_2_i)
+                                end
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_2_q_3 = (tmp_lvl_q - 1) * ref_lvl_2.shape + phase_stop_10
+                                    tmp_lvl_2_val[tmp_lvl_2_q_3] = ref_lvl_3_val_2
+                                    if !(tmp_lvl_tbl[tmp_lvl_2_q_3])
+                                        tmp_lvl_tbl[tmp_lvl_2_q_3] = true
+                                        tmp_lvl_2_qos_fill += 1
+                                        if tmp_lvl_2_qos_fill > tmp_lvl_2_qos_stop
+                                            tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
+                                        end
+                                        tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_q, phase_stop_10)
+                                    end
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     sort!(view(tmp_lvl_srt, 1:tmp_lvl_2_qos_fill))

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseCOO{1}(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseCOO{1}(Element(false)))).jl
@@ -27,15 +27,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 tmp_lvl_2_q = tmp_lvl_2_qos_fill + 1
                 tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
                 tmp_lvl_2_prev_coord_2 = ()
@@ -48,14 +46,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_q > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -64,13 +60,30 @@ begin
                                 Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q, tmp_lvl_2_qos_stop)
                             end
                             tmp_lvl_2_val[tmp_lvl_2_q] = ref_lvl_3_val
-                            tmp_lvl_2_prev_coord_2 < (phase_stop_4,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
-                            tmp_lvl_2_prev_coord_2 = (phase_stop_4,)
-                            tmp_lvl_tbl1[tmp_lvl_2_q] = phase_stop_4
+                            tmp_lvl_2_prev_coord_2 < (ref_lvl_2_i,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                            tmp_lvl_2_prev_coord_2 = (ref_lvl_2_i,)
+                            tmp_lvl_tbl1[tmp_lvl_2_q] = ref_lvl_2_i
                             tmp_lvl_2_q += 1
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_q > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q] = ref_lvl_3_val
+                                tmp_lvl_2_prev_coord_2 < (phase_stop_5,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                tmp_lvl_2_prev_coord_2 = (phase_stop_5,)
+                                tmp_lvl_tbl1[tmp_lvl_2_q] = phase_stop_5
+                                tmp_lvl_2_q += 1
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr[tmp_lvl_q + 1] = (tmp_lvl_2_q - tmp_lvl_2_qos_fill) - 1
@@ -79,8 +92,71 @@ begin
                 end
                 tmp_lvl_2_qos_fill = tmp_lvl_2_q - 1
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_7
+                    tmp_lvl_2_q_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                    tmp_lvl_2_prev_coord_3 = ()
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                tmp_lvl_2_prev_coord_3 < (ref_lvl_2_i,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                tmp_lvl_2_prev_coord_3 = (ref_lvl_2_i,)
+                                tmp_lvl_tbl1[tmp_lvl_2_q_2] = ref_lvl_2_i
+                                tmp_lvl_2_q_2 += 1
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                    tmp_lvl_2_prev_coord_3 < (phase_stop_10,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                    tmp_lvl_2_prev_coord_3 = (phase_stop_10,)
+                                    tmp_lvl_tbl1[tmp_lvl_2_q_2] = phase_stop_10
+                                    tmp_lvl_2_q_2 += 1
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr[tmp_lvl_q + 1] = (tmp_lvl_2_q_2 - tmp_lvl_2_qos_fill) - 1
+                    if (tmp_lvl_2_q_2 - tmp_lvl_2_qos_fill) - 1 > 0
+                        tmp_lvl_2_prev_pos = tmp_lvl_q
+                    end
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_q_2 - 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     for p = 2:ref_lvl.shape + 1

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseHash{1}(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseHash{1}(Element(false)))).jl
@@ -29,15 +29,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
                 ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
                 if ref_lvl_2_q < ref_lvl_2_q_stop
@@ -47,16 +45,14 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_2_key = (tmp_lvl_q, (phase_stop_4,))
+                            tmp_lvl_2_key = (tmp_lvl_q, (ref_lvl_2_i,))
                             tmp_lvl_2_q = get(tmp_lvl_tbl, tmp_lvl_2_key, tmp_lvl_2_qos_fill + 1)
                             if tmp_lvl_2_q > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -70,13 +66,91 @@ begin
                                 tmp_lvl_ptr[tmp_lvl_q + 1] += 1
                             end
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_key = (tmp_lvl_q, (phase_stop_5,))
+                                tmp_lvl_2_q = get(tmp_lvl_tbl, tmp_lvl_2_key, tmp_lvl_2_qos_fill + 1)
+                                if tmp_lvl_2_q > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q] = ref_lvl_3_val
+                                if tmp_lvl_2_q > tmp_lvl_2_qos_fill
+                                    tmp_lvl_2_qos_fill = tmp_lvl_2_q
+                                    tmp_lvl_tbl[tmp_lvl_2_key] = tmp_lvl_2_q
+                                    tmp_lvl_ptr[tmp_lvl_q + 1] += 1
+                                end
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_7
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_key_2 = (tmp_lvl_q, (ref_lvl_2_i,))
+                                tmp_lvl_2_q_2 = get(tmp_lvl_tbl, tmp_lvl_2_key_2, tmp_lvl_2_qos_fill + 1)
+                                if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                if tmp_lvl_2_q_2 > tmp_lvl_2_qos_fill
+                                    tmp_lvl_2_qos_fill = tmp_lvl_2_q_2
+                                    tmp_lvl_tbl[tmp_lvl_2_key_2] = tmp_lvl_2_q_2
+                                    tmp_lvl_ptr[tmp_lvl_q + 1] += 1
+                                end
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_2_key_2 = (tmp_lvl_q, (phase_stop_10,))
+                                    tmp_lvl_2_q_2 = get(tmp_lvl_tbl, tmp_lvl_2_key_2, tmp_lvl_2_qos_fill + 1)
+                                    if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                    if tmp_lvl_2_q_2 > tmp_lvl_2_qos_fill
+                                        tmp_lvl_2_qos_fill = tmp_lvl_2_q_2
+                                        tmp_lvl_tbl[tmp_lvl_2_key_2] = tmp_lvl_2_q_2
+                                        tmp_lvl_ptr[tmp_lvl_q + 1] += 1
+                                    end
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     resize!(tmp_lvl_srt, length(tmp_lvl_tbl))

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseList(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseList(Element(false)))).jl
@@ -27,15 +27,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 tmp_lvl_2_qos = tmp_lvl_2_qos_fill + 1
                 tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
@@ -47,14 +45,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -63,19 +59,92 @@ begin
                                 Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
-                            tmp_lvl_idx[tmp_lvl_2_qos] = phase_stop_4
+                            tmp_lvl_idx[tmp_lvl_2_qos] = ref_lvl_2_i
                             tmp_lvl_2_qos += 1
                             tmp_lvl_2_prev_pos = tmp_lvl_q
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                tmp_lvl_idx[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_q
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr[tmp_lvl_q + 1] = (tmp_lvl_2_qos - tmp_lvl_2_qos_fill) - 1
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_7
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                tmp_lvl_idx[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_q
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    tmp_lvl_idx[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_2_prev_pos = tmp_lvl_q
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr[tmp_lvl_q + 1] = (tmp_lvl_2_qos_2 - tmp_lvl_2_qos_fill) - 1
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     for p = 2:ref_lvl.shape + 1

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseRLE(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseRLE(Element(false)))).jl
@@ -28,15 +28,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 tmp_lvl_2_qos = tmp_lvl_2_qos_fill + 1
                 tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseRLELevels cannot be updated multiple times"))
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
@@ -48,14 +46,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -65,20 +61,99 @@ begin
                                 Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
-                            tmp_lvl_left[tmp_lvl_2_qos] = phase_stop_4
-                            tmp_lvl_right[tmp_lvl_2_qos] = phase_stop_4
+                            tmp_lvl_left[tmp_lvl_2_qos] = ref_lvl_2_i
+                            tmp_lvl_right[tmp_lvl_2_qos] = ref_lvl_2_i
                             tmp_lvl_2_qos += 1
                             tmp_lvl_2_prev_pos = tmp_lvl_q
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                tmp_lvl_left[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_right[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_q
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr[tmp_lvl_q + 1] = (tmp_lvl_2_qos - tmp_lvl_2_qos_fill) - 1
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_7
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseRLELevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                tmp_lvl_left[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_right[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_q
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    tmp_lvl_left[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_right[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_2_prev_pos = tmp_lvl_q
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr[tmp_lvl_q + 1] = (tmp_lvl_2_qos_2 - tmp_lvl_2_qos_fill) - 1
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     for p = 2:ref_lvl.shape + 1

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseTriangle{1}(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseTriangle{1}(Element(false)))).jl
@@ -22,15 +22,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 tmp_lvl_2_q = (tmp_lvl_q - 1) * fld(ref_lvl_2.shape, 1) + 1
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
                 ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
@@ -41,24 +39,65 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2.shape, ref_lvl_2_i1)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_2_val[tmp_lvl_2_q + -1 + phase_stop_4] = ref_lvl_3_val
+                            tmp_lvl_2_val[tmp_lvl_2_q + -1 + ref_lvl_2_i] = ref_lvl_3_val
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_val[tmp_lvl_2_q + -1 + phase_stop_5] = ref_lvl_3_val
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_9 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_9
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_9
+                    tmp_lvl_2_q_2 = (tmp_lvl_q - 1) * fld(ref_lvl_2.shape, 1) + 1
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_10 = min(ref_lvl_2.shape, ref_lvl_2_i1)
+                    if phase_stop_10 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_10
+                                ref_lvl_3_val_3 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_val[tmp_lvl_2_q_2 + -1 + ref_lvl_2_i] = ref_lvl_3_val_3
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_12 = min(ref_lvl_2_i, phase_stop_10)
+                                if ref_lvl_2_i == phase_stop_12
+                                    ref_lvl_3_val_3 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_2_val[tmp_lvl_2_q_2 + -1 + phase_stop_12] = ref_lvl_3_val_3
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     qos = 1 * ref_lvl.shape

--- a/test/reference64/convert_to_0×0 Fiber!(Dense(SparseVBL(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(Dense(SparseVBL(Element(false)))).jl
@@ -32,15 +32,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_2
+            if ref_lvl_i < phase_stop
+                tmp_lvl_q = (1 - 1) * ref_lvl.shape + ref_lvl_i
                 tmp_lvl_2_ros = tmp_lvl_2_ros_fill
                 tmp_lvl_2_qos = tmp_lvl_2_qos_fill + 1
                 tmp_lvl_2_i_prev = -1
@@ -54,14 +52,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -69,7 +65,7 @@ begin
                                 Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
-                            if phase_stop_4 > tmp_lvl_2_i_prev + 1
+                            if ref_lvl_2_i > tmp_lvl_2_i_prev + 1
                                 tmp_lvl_2_ros += 1
                                 if tmp_lvl_2_ros > tmp_lvl_2_ros_stop
                                     tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
@@ -77,21 +73,121 @@ begin
                                     Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
                                 end
                             end
-                            tmp_lvl_idx[tmp_lvl_2_ros] = (tmp_lvl_2_i_prev = phase_stop_4)
+                            tmp_lvl_idx[tmp_lvl_2_ros] = (tmp_lvl_2_i_prev = ref_lvl_2_i)
                             tmp_lvl_2_qos += 1
                             tmp_lvl_ofs[tmp_lvl_2_ros + 1] = tmp_lvl_2_qos
                             tmp_lvl_2_prev_pos = tmp_lvl_q
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                if phase_stop_5 > tmp_lvl_2_i_prev + 1
+                                    tmp_lvl_2_ros += 1
+                                    if tmp_lvl_2_ros > tmp_lvl_2_ros_stop
+                                        tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_2_ros_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
+                                    end
+                                end
+                                tmp_lvl_idx[tmp_lvl_2_ros] = (tmp_lvl_2_i_prev = phase_stop_5)
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_ofs[tmp_lvl_2_ros + 1] = tmp_lvl_2_qos
+                                tmp_lvl_2_prev_pos = tmp_lvl_q
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr[tmp_lvl_q + 1] = tmp_lvl_2_ros - tmp_lvl_2_ros_fill
                 tmp_lvl_2_ros_fill = tmp_lvl_2_ros
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    tmp_lvl_q = (1 - 1) * ref_lvl.shape + phase_stop_7
+                    tmp_lvl_2_ros_2 = tmp_lvl_2_ros_fill
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_i_prev_2 = -1
+                    tmp_lvl_2_prev_pos < tmp_lvl_q || throw(FinchProtocolError("SparseVBLLevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                if ref_lvl_2_i > tmp_lvl_2_i_prev_2 + 1
+                                    tmp_lvl_2_ros_2 += 1
+                                    if tmp_lvl_2_ros_2 > tmp_lvl_2_ros_stop
+                                        tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_2_ros_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
+                                    end
+                                end
+                                tmp_lvl_idx[tmp_lvl_2_ros_2] = (tmp_lvl_2_i_prev_2 = ref_lvl_2_i)
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_ofs[tmp_lvl_2_ros_2 + 1] = tmp_lvl_2_qos_2
+                                tmp_lvl_2_prev_pos = tmp_lvl_q
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    if phase_stop_10 > tmp_lvl_2_i_prev_2 + 1
+                                        tmp_lvl_2_ros_2 += 1
+                                        if tmp_lvl_2_ros_2 > tmp_lvl_2_ros_stop
+                                            tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
+                                            Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_2_ros_stop)
+                                            Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
+                                        end
+                                    end
+                                    tmp_lvl_idx[tmp_lvl_2_ros_2] = (tmp_lvl_2_i_prev_2 = phase_stop_10)
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_ofs[tmp_lvl_2_ros_2 + 1] = tmp_lvl_2_qos_2
+                                    tmp_lvl_2_prev_pos = tmp_lvl_q
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr[tmp_lvl_q + 1] = tmp_lvl_2_ros_2 - tmp_lvl_2_ros_fill
+                    tmp_lvl_2_ros_fill = tmp_lvl_2_ros_2
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     for p = 2:ref_lvl.shape + 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseCOO{2}(Element(false))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseCOO{2}(Element(false))).jl
@@ -27,14 +27,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
                 ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
                 if ref_lvl_2_q < ref_lvl_2_q_stop
@@ -44,14 +42,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_q > tmp_lvl_qos_stop
                                 tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -61,19 +57,96 @@ begin
                                 Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
                             end
                             tmp_lvl_val[tmp_lvl_q] = ref_lvl_3_val
-                            tmp_lvl_prev_coord_3 < (phase_stop_2, phase_stop_4) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
-                            tmp_lvl_prev_coord_3 = (phase_stop_2, phase_stop_4)
-                            tmp_lvl_tbl1[tmp_lvl_q] = phase_stop_4
-                            tmp_lvl_tbl2[tmp_lvl_q] = phase_stop_2
+                            tmp_lvl_prev_coord_3 < (ref_lvl_i, ref_lvl_2_i) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                            tmp_lvl_prev_coord_3 = (ref_lvl_i, ref_lvl_2_i)
+                            tmp_lvl_tbl1[tmp_lvl_q] = ref_lvl_2_i
+                            tmp_lvl_tbl2[tmp_lvl_q] = ref_lvl_i
                             tmp_lvl_q += 1
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_q > tmp_lvl_qos_stop
+                                    tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl2, tmp_lvl_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
+                                end
+                                tmp_lvl_val[tmp_lvl_q] = ref_lvl_3_val
+                                tmp_lvl_prev_coord_3 < (ref_lvl_i, phase_stop_5) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                tmp_lvl_prev_coord_3 = (ref_lvl_i, phase_stop_5)
+                                tmp_lvl_tbl1[tmp_lvl_q] = phase_stop_5
+                                tmp_lvl_tbl2[tmp_lvl_q] = ref_lvl_i
+                                tmp_lvl_q += 1
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_q > tmp_lvl_qos_stop
+                                    tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl2, tmp_lvl_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
+                                end
+                                tmp_lvl_val[tmp_lvl_q] = ref_lvl_3_val_2
+                                tmp_lvl_prev_coord_3 < (phase_stop_7, ref_lvl_2_i) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                tmp_lvl_prev_coord_3 = (phase_stop_7, ref_lvl_2_i)
+                                tmp_lvl_tbl1[tmp_lvl_q] = ref_lvl_2_i
+                                tmp_lvl_tbl2[tmp_lvl_q] = phase_stop_7
+                                tmp_lvl_q += 1
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_q > tmp_lvl_qos_stop
+                                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_tbl2, tmp_lvl_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q, tmp_lvl_qos_stop)
+                                    end
+                                    tmp_lvl_val[tmp_lvl_q] = ref_lvl_3_val_2
+                                    tmp_lvl_prev_coord_3 < (phase_stop_7, phase_stop_10) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                    tmp_lvl_prev_coord_3 = (phase_stop_7, phase_stop_10)
+                                    tmp_lvl_tbl1[tmp_lvl_q] = phase_stop_10
+                                    tmp_lvl_tbl2[tmp_lvl_q] = phase_stop_7
+                                    tmp_lvl_q += 1
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_q - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseHash{2}(Element(false))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseHash{2}(Element(false))).jl
@@ -27,14 +27,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
                 ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
                 if ref_lvl_2_q < ref_lvl_2_q_stop
@@ -44,16 +42,14 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_key_2 = (1, (phase_stop_4, phase_stop_2))
+                            tmp_lvl_key_2 = (1, (ref_lvl_2_i, ref_lvl_i))
                             tmp_lvl_q_2 = get(tmp_lvl_tbl, tmp_lvl_key_2, tmp_lvl_qos_fill + 1)
                             if tmp_lvl_q_2 > tmp_lvl_qos_stop
                                 tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
@@ -67,13 +63,90 @@ begin
                                 tmp_lvl_ptr[1 + 1] += 1
                             end
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_key_2 = (1, (phase_stop_5, ref_lvl_i))
+                                tmp_lvl_q_2 = get(tmp_lvl_tbl, tmp_lvl_key_2, tmp_lvl_qos_fill + 1)
+                                if tmp_lvl_q_2 > tmp_lvl_qos_stop
+                                    tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q_2, tmp_lvl_qos_stop)
+                                end
+                                tmp_lvl_val[tmp_lvl_q_2] = ref_lvl_3_val
+                                if tmp_lvl_q_2 > tmp_lvl_qos_fill
+                                    tmp_lvl_qos_fill = tmp_lvl_q_2
+                                    tmp_lvl_tbl[tmp_lvl_key_2] = tmp_lvl_q_2
+                                    tmp_lvl_ptr[1 + 1] += 1
+                                end
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_key_3 = (1, (ref_lvl_2_i, phase_stop_7))
+                                tmp_lvl_q_3 = get(tmp_lvl_tbl, tmp_lvl_key_3, tmp_lvl_qos_fill + 1)
+                                if tmp_lvl_q_3 > tmp_lvl_qos_stop
+                                    tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q_3, tmp_lvl_qos_stop)
+                                end
+                                tmp_lvl_val[tmp_lvl_q_3] = ref_lvl_3_val_2
+                                if tmp_lvl_q_3 > tmp_lvl_qos_fill
+                                    tmp_lvl_qos_fill = tmp_lvl_q_3
+                                    tmp_lvl_tbl[tmp_lvl_key_3] = tmp_lvl_q_3
+                                    tmp_lvl_ptr[1 + 1] += 1
+                                end
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_key_3 = (1, (phase_stop_10, phase_stop_7))
+                                    tmp_lvl_q_3 = get(tmp_lvl_tbl, tmp_lvl_key_3, tmp_lvl_qos_fill + 1)
+                                    if tmp_lvl_q_3 > tmp_lvl_qos_stop
+                                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_val, tmp_lvl_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_val, false, tmp_lvl_q_3, tmp_lvl_qos_stop)
+                                    end
+                                    tmp_lvl_val[tmp_lvl_q_3] = ref_lvl_3_val_2
+                                    if tmp_lvl_q_3 > tmp_lvl_qos_fill
+                                        tmp_lvl_qos_fill = tmp_lvl_q_3
+                                        tmp_lvl_tbl[tmp_lvl_key_3] = tmp_lvl_q_3
+                                        tmp_lvl_ptr[1 + 1] += 1
+                                    end
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     resize!(tmp_lvl_srt, length(tmp_lvl_tbl))

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseByteMap(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseByteMap(Element(false)))).jl
@@ -42,14 +42,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -72,16 +70,14 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_2_q_2 = (tmp_lvl_qos - 1) * ref_lvl_2.shape + phase_stop_4
+                            tmp_lvl_2_q_2 = (tmp_lvl_qos - 1) * ref_lvl_2.shape + ref_lvl_2_i
                             tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val
                             tmp_lvldirty = true
                             if !(tmp_lvl_tbl[tmp_lvl_2_q_2])
@@ -91,20 +87,111 @@ begin
                                     tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
                                     Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
                                 end
-                                tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_qos, phase_stop_4)
+                                tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_qos, ref_lvl_2_i)
                             end
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_q_2 = (tmp_lvl_qos - 1) * ref_lvl_2.shape + phase_stop_5
+                                tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val
+                                tmp_lvldirty = true
+                                if !(tmp_lvl_tbl[tmp_lvl_2_q_2])
+                                    tmp_lvl_tbl[tmp_lvl_2_q_2] = true
+                                    tmp_lvl_2_qos_fill += 1
+                                    if tmp_lvl_2_qos_fill > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_qos, phase_stop_5)
+                                end
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        tmp_lvl_2q_start_2 = (tmp_lvl_qos - 1) * ref_lvl_2.shape + 1
+                        tmp_lvl_2q_stop_2 = tmp_lvl_qos_stop * ref_lvl_2.shape
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                        Finch.resize_if_smaller!(tmp_lvl_tbl, tmp_lvl_2q_stop_2)
+                        Finch.fill_range!(tmp_lvl_tbl, false, tmp_lvl_2q_start_2, tmp_lvl_2q_stop_2)
+                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2q_stop_2)
+                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2q_start_2, tmp_lvl_2q_stop_2)
+                    end
+                    tmp_lvldirty = false
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_q_3 = (tmp_lvl_qos - 1) * ref_lvl_2.shape + ref_lvl_2_i
+                                tmp_lvl_2_val[tmp_lvl_2_q_3] = ref_lvl_3_val_2
+                                tmp_lvldirty = true
+                                if !(tmp_lvl_tbl[tmp_lvl_2_q_3])
+                                    tmp_lvl_tbl[tmp_lvl_2_q_3] = true
+                                    tmp_lvl_2_qos_fill += 1
+                                    if tmp_lvl_2_qos_fill > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_qos, ref_lvl_2_i)
+                                end
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_2_q_3 = (tmp_lvl_qos - 1) * ref_lvl_2.shape + phase_stop_10
+                                    tmp_lvl_2_val[tmp_lvl_2_q_3] = ref_lvl_3_val_2
+                                    tmp_lvldirty = true
+                                    if !(tmp_lvl_tbl[tmp_lvl_2_q_3])
+                                        tmp_lvl_tbl[tmp_lvl_2_q_3] = true
+                                        tmp_lvl_2_qos_fill += 1
+                                        if tmp_lvl_2_qos_fill > tmp_lvl_2_qos_stop
+                                            tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(tmp_lvl_srt, tmp_lvl_2_qos_stop)
+                                        end
+                                        tmp_lvl_srt[tmp_lvl_2_qos_fill] = (tmp_lvl_qos, phase_stop_10)
+                                    end
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseCOO{1}(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseCOO{1}(Element(false)))).jl
@@ -31,14 +31,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -58,14 +56,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_q > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -74,14 +70,32 @@ begin
                                 Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q, tmp_lvl_2_qos_stop)
                             end
                             tmp_lvl_2_val[tmp_lvl_2_q] = ref_lvl_3_val
-                            tmp_lvl_2_prev_coord_2 < (phase_stop_4,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
-                            tmp_lvl_2_prev_coord_2 = (phase_stop_4,)
+                            tmp_lvl_2_prev_coord_2 < (ref_lvl_2_i,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                            tmp_lvl_2_prev_coord_2 = (ref_lvl_2_i,)
                             tmp_lvldirty = true
-                            tmp_lvl_tbl1[tmp_lvl_2_q] = phase_stop_4
+                            tmp_lvl_tbl1[tmp_lvl_2_q] = ref_lvl_2_i
                             tmp_lvl_2_q += 1
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_q > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q] = ref_lvl_3_val
+                                tmp_lvl_2_prev_coord_2 < (phase_stop_5,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                tmp_lvl_2_prev_coord_2 = (phase_stop_5,)
+                                tmp_lvldirty = true
+                                tmp_lvl_tbl1[tmp_lvl_2_q] = phase_stop_5
+                                tmp_lvl_2_q += 1
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_q - tmp_lvl_2_qos_fill) - 1
@@ -90,12 +104,87 @@ begin
                 end
                 tmp_lvl_2_qos_fill = tmp_lvl_2_q - 1
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                    end
+                    tmp_lvldirty = false
+                    tmp_lvl_2_q_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_qos || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                    tmp_lvl_2_prev_coord_3 = ()
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                tmp_lvl_2_prev_coord_3 < (ref_lvl_2_i,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                tmp_lvl_2_prev_coord_3 = (ref_lvl_2_i,)
+                                tmp_lvldirty = true
+                                tmp_lvl_tbl1[tmp_lvl_2_q_2] = ref_lvl_2_i
+                                tmp_lvl_2_q_2 += 1
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_tbl1, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                    tmp_lvl_2_prev_coord_3 < (phase_stop_10,) || throw(FinchProtocolError("SparseCOOLevels cannot be updated multiple times"))
+                                    tmp_lvl_2_prev_coord_3 = (phase_stop_10,)
+                                    tmp_lvldirty = true
+                                    tmp_lvl_tbl1[tmp_lvl_2_q_2] = phase_stop_10
+                                    tmp_lvl_2_q_2 += 1
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_q_2 - tmp_lvl_2_qos_fill) - 1
+                    if (tmp_lvl_2_q_2 - tmp_lvl_2_qos_fill) - 1 > 0
+                        tmp_lvl_2_prev_pos = tmp_lvl_qos
+                    end
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_q_2 - 1
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseHash{1}(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseHash{1}(Element(false)))).jl
@@ -33,14 +33,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -57,16 +55,14 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_2_key = (tmp_lvl_qos, (phase_stop_4,))
+                            tmp_lvl_2_key = (tmp_lvl_qos, (ref_lvl_2_i,))
                             tmp_lvl_2_q = get(tmp_lvl_tbl, tmp_lvl_2_key, tmp_lvl_2_qos_fill + 1)
                             if tmp_lvl_2_q > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -81,17 +77,108 @@ begin
                                 tmp_lvl_ptr_2[tmp_lvl_qos + 1] += 1
                             end
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_key = (tmp_lvl_qos, (phase_stop_5,))
+                                tmp_lvl_2_q = get(tmp_lvl_tbl, tmp_lvl_2_key, tmp_lvl_2_qos_fill + 1)
+                                if tmp_lvl_2_q > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q] = ref_lvl_3_val
+                                tmp_lvldirty = true
+                                if tmp_lvl_2_q > tmp_lvl_2_qos_fill
+                                    tmp_lvl_2_qos_fill = tmp_lvl_2_q
+                                    tmp_lvl_tbl[tmp_lvl_2_key] = tmp_lvl_2_q
+                                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] += 1
+                                end
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                    end
+                    tmp_lvldirty = false
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_2_key_2 = (tmp_lvl_qos, (ref_lvl_2_i,))
+                                tmp_lvl_2_q_2 = get(tmp_lvl_tbl, tmp_lvl_2_key_2, tmp_lvl_2_qos_fill + 1)
+                                if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                tmp_lvldirty = true
+                                if tmp_lvl_2_q_2 > tmp_lvl_2_qos_fill
+                                    tmp_lvl_2_qos_fill = tmp_lvl_2_q_2
+                                    tmp_lvl_tbl[tmp_lvl_2_key_2] = tmp_lvl_2_q_2
+                                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] += 1
+                                end
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_2_key_2 = (tmp_lvl_qos, (phase_stop_10,))
+                                    tmp_lvl_2_q_2 = get(tmp_lvl_tbl, tmp_lvl_2_key_2, tmp_lvl_2_qos_fill + 1)
+                                    if tmp_lvl_2_q_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_q_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_q_2] = ref_lvl_3_val_2
+                                    tmp_lvldirty = true
+                                    if tmp_lvl_2_q_2 > tmp_lvl_2_qos_fill
+                                        tmp_lvl_2_qos_fill = tmp_lvl_2_q_2
+                                        tmp_lvl_tbl[tmp_lvl_2_key_2] = tmp_lvl_2_q_2
+                                        tmp_lvl_ptr_2[tmp_lvl_qos + 1] += 1
+                                    end
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseList(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseList(Element(false)))).jl
@@ -31,14 +31,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -57,14 +55,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -74,23 +70,109 @@ begin
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
                             tmp_lvldirty = true
-                            tmp_lvl_idx_2[tmp_lvl_2_qos] = phase_stop_4
+                            tmp_lvl_idx_2[tmp_lvl_2_qos] = ref_lvl_2_i
                             tmp_lvl_2_qos += 1
                             tmp_lvl_2_prev_pos = tmp_lvl_qos
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_idx_2, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                tmp_lvldirty = true
+                                tmp_lvl_idx_2[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_qos - tmp_lvl_2_qos_fill) - 1
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                    end
+                    tmp_lvldirty = false
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_qos || throw(FinchProtocolError("SparseListLevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_idx_2, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                tmp_lvldirty = true
+                                tmp_lvl_idx_2[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_idx_2, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    tmp_lvldirty = true
+                                    tmp_lvl_idx_2[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_qos_2 - tmp_lvl_2_qos_fill) - 1
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseRLE(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseRLE(Element(false)))).jl
@@ -32,14 +32,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -58,14 +56,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -76,24 +72,116 @@ begin
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
                             tmp_lvldirty = true
-                            tmp_lvl_left[tmp_lvl_2_qos] = phase_stop_4
-                            tmp_lvl_right[tmp_lvl_2_qos] = phase_stop_4
+                            tmp_lvl_left[tmp_lvl_2_qos] = ref_lvl_2_i
+                            tmp_lvl_right[tmp_lvl_2_qos] = ref_lvl_2_i
                             tmp_lvl_2_qos += 1
                             tmp_lvl_2_prev_pos = tmp_lvl_qos
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                tmp_lvldirty = true
+                                tmp_lvl_left[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_right[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_qos - tmp_lvl_2_qos_fill) - 1
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                    end
+                    tmp_lvldirty = false
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_qos || throw(FinchProtocolError("SparseRLELevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                tmp_lvldirty = true
+                                tmp_lvl_left[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_right[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    tmp_lvldirty = true
+                                    tmp_lvl_left[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_right[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_qos_2 - tmp_lvl_2_qos_fill) - 1
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseTriangle{1}(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseTriangle{1}(Element(false)))).jl
@@ -26,14 +26,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -53,29 +51,85 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2.shape, ref_lvl_2_i1)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             tmp_lvldirty = true
-                            tmp_lvl_2_val[tmp_lvl_2_q + -1 + phase_stop_4] = ref_lvl_3_val
+                            tmp_lvl_2_val[tmp_lvl_2_q + -1 + ref_lvl_2_i] = ref_lvl_3_val
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvldirty = true
+                                tmp_lvl_2_val[tmp_lvl_2_q + -1 + phase_stop_5] = ref_lvl_3_val
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_9 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_9
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        pos_start_2 = 1 + fld(ref_lvl_2.shape, 1) * (-1 + tmp_lvl_qos)
+                        pos_stop_2 = fld(ref_lvl_2.shape, 1) * tmp_lvl_qos_stop
+                        Finch.resize_if_smaller!(tmp_lvl_2_val, pos_stop_2)
+                        Finch.fill_range!(tmp_lvl_2_val, false, pos_start_2, pos_stop_2)
+                    end
+                    tmp_lvldirty = false
+                    tmp_lvl_2_q_2 = (tmp_lvl_qos - 1) * fld(ref_lvl_2.shape, 1) + 1
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_10 = min(ref_lvl_2.shape, ref_lvl_2_i1)
+                    if phase_stop_10 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_10
+                                ref_lvl_3_val_3 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvldirty = true
+                                tmp_lvl_2_val[tmp_lvl_2_q_2 + -1 + ref_lvl_2_i] = ref_lvl_3_val_3
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_12 = min(ref_lvl_2_i, phase_stop_10)
+                                if ref_lvl_2_i == phase_stop_12
+                                    ref_lvl_3_val_3 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvldirty = true
+                                    tmp_lvl_2_val[tmp_lvl_2_q_2 + -1 + phase_stop_12] = ref_lvl_3_val_3
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_9
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseVBL(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseList(SparseVBL(Element(false)))).jl
@@ -36,14 +36,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
@@ -64,14 +62,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -80,7 +76,7 @@ begin
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
                             tmp_lvldirty = true
-                            if phase_stop_4 > tmp_lvl_2_i_prev + 1
+                            if ref_lvl_2_i > tmp_lvl_2_i_prev + 1
                                 tmp_lvl_2_ros += 1
                                 if tmp_lvl_2_ros > tmp_lvl_2_ros_stop
                                     tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
@@ -88,25 +84,138 @@ begin
                                     Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
                                 end
                             end
-                            tmp_lvl_idx_2[tmp_lvl_2_ros] = (tmp_lvl_2_i_prev = phase_stop_4)
+                            tmp_lvl_idx_2[tmp_lvl_2_ros] = (tmp_lvl_2_i_prev = ref_lvl_2_i)
                             tmp_lvl_2_qos += 1
                             tmp_lvl_ofs[tmp_lvl_2_ros + 1] = tmp_lvl_2_qos
                             tmp_lvl_2_prev_pos = tmp_lvl_qos
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                tmp_lvldirty = true
+                                if phase_stop_5 > tmp_lvl_2_i_prev + 1
+                                    tmp_lvl_2_ros += 1
+                                    if tmp_lvl_2_ros > tmp_lvl_2_ros_stop
+                                        tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_idx_2, tmp_lvl_2_ros_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
+                                    end
+                                end
+                                tmp_lvl_idx_2[tmp_lvl_2_ros] = (tmp_lvl_2_i_prev = phase_stop_5)
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_ofs[tmp_lvl_2_ros + 1] = tmp_lvl_2_qos
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr_2[tmp_lvl_qos + 1] = tmp_lvl_2_ros - tmp_lvl_2_ros_fill
                 tmp_lvl_2_ros_fill = tmp_lvl_2_ros
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 if tmp_lvldirty
-                    tmp_lvl_idx[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_idx[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_idx, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                    end
+                    tmp_lvldirty = false
+                    tmp_lvl_2_ros_2 = tmp_lvl_2_ros_fill
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_i_prev_2 = -1
+                    tmp_lvl_2_prev_pos < tmp_lvl_qos || throw(FinchProtocolError("SparseVBLLevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                tmp_lvldirty = true
+                                if ref_lvl_2_i > tmp_lvl_2_i_prev_2 + 1
+                                    tmp_lvl_2_ros_2 += 1
+                                    if tmp_lvl_2_ros_2 > tmp_lvl_2_ros_stop
+                                        tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_idx_2, tmp_lvl_2_ros_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
+                                    end
+                                end
+                                tmp_lvl_idx_2[tmp_lvl_2_ros_2] = (tmp_lvl_2_i_prev_2 = ref_lvl_2_i)
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_ofs[tmp_lvl_2_ros_2 + 1] = tmp_lvl_2_qos_2
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    tmp_lvldirty = true
+                                    if phase_stop_10 > tmp_lvl_2_i_prev_2 + 1
+                                        tmp_lvl_2_ros_2 += 1
+                                        if tmp_lvl_2_ros_2 > tmp_lvl_2_ros_stop
+                                            tmp_lvl_2_ros_stop = max(tmp_lvl_2_ros_stop << 1, 1)
+                                            Finch.resize_if_smaller!(tmp_lvl_idx_2, tmp_lvl_2_ros_stop)
+                                            Finch.resize_if_smaller!(tmp_lvl_ofs, tmp_lvl_2_ros_stop + 1)
+                                        end
+                                    end
+                                    tmp_lvl_idx_2[tmp_lvl_2_ros_2] = (tmp_lvl_2_i_prev_2 = phase_stop_10)
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_ofs[tmp_lvl_2_ros_2 + 1] = tmp_lvl_2_qos_2
+                                    tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] = tmp_lvl_2_ros_2 - tmp_lvl_2_ros_fill
+                    tmp_lvl_2_ros_fill = tmp_lvl_2_ros_2
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    if tmp_lvldirty
+                        tmp_lvl_idx[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseRLE(SparseRLE(Element(false)))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseRLE(SparseRLE(Element(false)))).jl
@@ -33,14 +33,12 @@ begin
     end
     phase_stop = min(ref_lvl_i1, ref_lvl.shape)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
+            if ref_lvl_i < phase_stop
                 if tmp_lvl_qos > tmp_lvl_qos_stop
                     tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
                     Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_qos_stop)
@@ -60,14 +58,12 @@ begin
                 end
                 phase_stop_3 = min(ref_lvl_2_i1, ref_lvl_2.shape)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
                             if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
                                 tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
@@ -78,25 +74,119 @@ begin
                             end
                             tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
                             tmp_lvldirty = true
-                            tmp_lvl_left_2[tmp_lvl_2_qos] = phase_stop_4
-                            tmp_lvl_right_2[tmp_lvl_2_qos] = phase_stop_4
+                            tmp_lvl_left_2[tmp_lvl_2_qos] = ref_lvl_2_i
+                            tmp_lvl_right_2[tmp_lvl_2_qos] = ref_lvl_2_i
                             tmp_lvl_2_qos += 1
                             tmp_lvl_2_prev_pos = tmp_lvl_qos
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_left_2, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_right_2, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos] = ref_lvl_3_val
+                                tmp_lvldirty = true
+                                tmp_lvl_left_2[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_right_2[tmp_lvl_2_qos] = phase_stop_5
+                                tmp_lvl_2_qos += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_qos - tmp_lvl_2_qos_fill) - 1
                 tmp_lvl_2_qos_fill = tmp_lvl_2_qos - 1
                 if tmp_lvldirty
-                    tmp_lvl_left[tmp_lvl_qos] = phase_stop_2
-                    tmp_lvl_right[tmp_lvl_qos] = phase_stop_2
+                    tmp_lvl_left[tmp_lvl_qos] = ref_lvl_i
+                    tmp_lvl_right[tmp_lvl_qos] = ref_lvl_i
                     tmp_lvl_qos += 1
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_7 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_7
+                    if tmp_lvl_qos > tmp_lvl_qos_stop
+                        tmp_lvl_qos_stop = max(tmp_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(tmp_lvl_left, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_right, tmp_lvl_qos_stop)
+                        Finch.resize_if_smaller!(tmp_lvl_ptr_2, tmp_lvl_qos_stop + 1)
+                        Finch.fill_range!(tmp_lvl_ptr_2, 0, tmp_lvl_qos + 1, tmp_lvl_qos_stop + 1)
+                    end
+                    tmp_lvldirty = false
+                    tmp_lvl_2_qos_2 = tmp_lvl_2_qos_fill + 1
+                    tmp_lvl_2_prev_pos < tmp_lvl_qos || throw(FinchProtocolError("SparseRLELevels cannot be updated multiple times"))
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_8 = min(ref_lvl_2_i1, ref_lvl_2.shape)
+                    if phase_stop_8 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_8
+                                ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                    tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(tmp_lvl_left_2, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_right_2, tmp_lvl_2_qos_stop)
+                                    Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                    Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                end
+                                tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                tmp_lvldirty = true
+                                tmp_lvl_left_2[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_right_2[tmp_lvl_2_qos_2] = ref_lvl_2_i
+                                tmp_lvl_2_qos_2 += 1
+                                tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_10 = min(ref_lvl_2_i, phase_stop_8)
+                                if ref_lvl_2_i == phase_stop_10
+                                    ref_lvl_3_val_2 = ref_lvl_2_val[ref_lvl_2_q]
+                                    if tmp_lvl_2_qos_2 > tmp_lvl_2_qos_stop
+                                        tmp_lvl_2_qos_stop = max(tmp_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(tmp_lvl_left_2, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_right_2, tmp_lvl_2_qos_stop)
+                                        Finch.resize_if_smaller!(tmp_lvl_2_val, tmp_lvl_2_qos_stop)
+                                        Finch.fill_range!(tmp_lvl_2_val, false, tmp_lvl_2_qos_2, tmp_lvl_2_qos_stop)
+                                    end
+                                    tmp_lvl_2_val[tmp_lvl_2_qos_2] = ref_lvl_3_val_2
+                                    tmp_lvldirty = true
+                                    tmp_lvl_left_2[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_right_2[tmp_lvl_2_qos_2] = phase_stop_10
+                                    tmp_lvl_2_qos_2 += 1
+                                    tmp_lvl_2_prev_pos = tmp_lvl_qos
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    tmp_lvl_ptr_2[tmp_lvl_qos + 1] = (tmp_lvl_2_qos_2 - tmp_lvl_2_qos_fill) - 1
+                    tmp_lvl_2_qos_fill = tmp_lvl_2_qos_2 - 1
+                    if tmp_lvldirty
+                        tmp_lvl_left[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_right[tmp_lvl_qos] = phase_stop_7
+                        tmp_lvl_qos += 1
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     tmp_lvl_ptr[1 + 1] = (tmp_lvl_qos - 0) - 1

--- a/test/reference64/convert_to_0×0 Fiber!(SparseTriangle{2}(Element(false))).jl
+++ b/test/reference64/convert_to_0×0 Fiber!(SparseTriangle{2}(Element(false))).jl
@@ -22,15 +22,13 @@ begin
     end
     phase_stop = min(ref_lvl.shape, ref_lvl_i1)
     if phase_stop >= 1
-        j = 1
         if ref_lvl_idx[ref_lvl_q] < 1
             ref_lvl_q = Finch.scansearch(ref_lvl_idx, 1, ref_lvl_q, ref_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             ref_lvl_i = ref_lvl_idx[ref_lvl_q]
-            phase_stop_2 = min(phase_stop, ref_lvl_i)
-            if ref_lvl_i == phase_stop_2
-                tmp_lvl_s = tmp_lvl_q + fld(phase_stop_2 * (-1 + phase_stop_2), 2)
+            if ref_lvl_i < phase_stop
+                tmp_lvl_s = tmp_lvl_q + fld(ref_lvl_i * (-1 + ref_lvl_i), 2)
                 ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
                 ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
                 if ref_lvl_2_q < ref_lvl_2_q_stop
@@ -38,26 +36,66 @@ begin
                 else
                     ref_lvl_2_i1 = 0
                 end
-                phase_stop_3 = min(phase_stop_2, ref_lvl_2.shape, ref_lvl_2_i1)
+                phase_stop_3 = min(ref_lvl_i, ref_lvl_2.shape, ref_lvl_2_i1)
                 if phase_stop_3 >= 1
-                    i = 1
                     if ref_lvl_idx_2[ref_lvl_2_q] < 1
                         ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
-                        phase_stop_4 = min(phase_stop_3, ref_lvl_2_i)
-                        if ref_lvl_2_i == phase_stop_4
+                        if ref_lvl_2_i < phase_stop_3
                             ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
-                            tmp_lvl_val[tmp_lvl_s + -1 + phase_stop_4] = ref_lvl_3_val
+                            tmp_lvl_val[tmp_lvl_s + -1 + ref_lvl_2_i] = ref_lvl_3_val
                             ref_lvl_2_q += 1
+                        else
+                            phase_stop_5 = min(ref_lvl_2_i, phase_stop_3)
+                            if ref_lvl_2_i == phase_stop_5
+                                ref_lvl_3_val = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_val[tmp_lvl_s + -1 + phase_stop_5] = ref_lvl_3_val
+                                ref_lvl_2_q += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 ref_lvl_q += 1
+            else
+                phase_stop_9 = min(ref_lvl_i, phase_stop)
+                if ref_lvl_i == phase_stop_9
+                    tmp_lvl_s = tmp_lvl_q + fld(phase_stop_9 * (-1 + phase_stop_9), 2)
+                    ref_lvl_2_q = ref_lvl_ptr_2[ref_lvl_q]
+                    ref_lvl_2_q_stop = ref_lvl_ptr_2[ref_lvl_q + 1]
+                    if ref_lvl_2_q < ref_lvl_2_q_stop
+                        ref_lvl_2_i1 = ref_lvl_idx_2[ref_lvl_2_q_stop - 1]
+                    else
+                        ref_lvl_2_i1 = 0
+                    end
+                    phase_stop_10 = min(ref_lvl_2.shape, ref_lvl_2_i1, phase_stop_9)
+                    if phase_stop_10 >= 1
+                        if ref_lvl_idx_2[ref_lvl_2_q] < 1
+                            ref_lvl_2_q = Finch.scansearch(ref_lvl_idx_2, 1, ref_lvl_2_q, ref_lvl_2_q_stop - 1)
+                        end
+                        while true
+                            ref_lvl_2_i = ref_lvl_idx_2[ref_lvl_2_q]
+                            if ref_lvl_2_i < phase_stop_10
+                                ref_lvl_3_val_3 = ref_lvl_2_val[ref_lvl_2_q]
+                                tmp_lvl_val[tmp_lvl_s + -1 + ref_lvl_2_i] = ref_lvl_3_val_3
+                                ref_lvl_2_q += 1
+                            else
+                                phase_stop_12 = min(ref_lvl_2_i, phase_stop_10)
+                                if ref_lvl_2_i == phase_stop_12
+                                    ref_lvl_3_val_3 = ref_lvl_2_val[ref_lvl_2_q]
+                                    tmp_lvl_val[tmp_lvl_s + -1 + phase_stop_12] = ref_lvl_3_val_3
+                                    ref_lvl_2_q += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    ref_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     resize!(tmp_lvl_val, 1 * fld(ref_lvl.shape * (1 + ref_lvl.shape), 2))

--- a/test/reference64/debug_parallel_spmv.txt
+++ b/test/reference64/debug_parallel_spmv.txt
@@ -42,21 +42,28 @@ quote
                     end
                     phase_stop_3 = min(A_lvl_2.shape, A_lvl_2_i1)
                     if phase_stop_3 >= 1
-                        i = 1
                         if A_lvl_idx[A_lvl_2_q] < 1
                             A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
                         end
-                        while i <= phase_stop_3
+                        while true
                             A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                            phase_stop_4 = min(phase_stop_3, A_lvl_2_i)
-                            if A_lvl_2_i == phase_stop_4
+                            if A_lvl_2_i < phase_stop_3
                                 A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
-                                x_lvl_q = (1 - 1) * x_lvl.shape + phase_stop_4
+                                x_lvl_q = (1 - 1) * x_lvl.shape + A_lvl_2_i
                                 x_lvl_2_val = x_lvl_val[x_lvl_q]
                                 y_lvl_val[y_lvl_q] = y_lvl_val[y_lvl_q] + A_lvl_3_val * x_lvl_2_val
                                 A_lvl_2_q += 1
+                            else
+                                phase_stop_5 = min(A_lvl_2_i, phase_stop_3)
+                                if A_lvl_2_i == phase_stop_5
+                                    A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                                    x_lvl_q = (1 - 1) * x_lvl.shape + phase_stop_5
+                                    x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
+                                    y_lvl_val[y_lvl_q] = y_lvl_val[y_lvl_q] + A_lvl_3_val * x_lvl_2_val_2
+                                    A_lvl_2_q += 1
+                                end
+                                break
                             end
-                            i = phase_stop_4 + 1
                         end
                     end
                 end

--- a/test/reference64/fiber_as_idx.jl
+++ b/test/reference64/fiber_as_idx.jl
@@ -18,11 +18,10 @@ begin
     if I_lvl_idx[I_lvl_q] < 1
         I_lvl_q = Finch.scansearch(I_lvl_idx, 1, I_lvl_q, I_lvl_q_stop - 1)
     end
-    while i <= A_lvl.shape
+    while true
         I_lvl_i = I_lvl_idx[I_lvl_q]
-        phase_stop = min(A_lvl.shape, I_lvl_i)
-        if I_lvl_i == phase_stop
-            for i_6 = i:phase_stop
+        if I_lvl_i < A_lvl.shape
+            for i_6 = i:I_lvl_i
                 B_lvl_q = (1 - 1) * A_lvl.shape + i_6
                 A_lvl_q = (1 - 1) * A_lvl.shape + i_6
                 s_2 = I_lvl_val[I_lvl_q]
@@ -31,17 +30,32 @@ begin
                 B_lvl_val[B_lvl_q] = A_lvl_3_val
             end
             I_lvl_q += 1
+            i = I_lvl_i + 1
         else
-            for i_7 = i:phase_stop
-                B_lvl_q = (1 - 1) * A_lvl.shape + i_7
-                A_lvl_q = (1 - 1) * A_lvl.shape + i_7
-                s_3 = I_lvl_val[I_lvl_q]
-                A_lvl_2_q_2 = (A_lvl_q - 1) * A_lvl_2.shape + s_3
-                A_lvl_3_val_2 = A_lvl_2_val[A_lvl_2_q_2]
-                B_lvl_val[B_lvl_q] = A_lvl_3_val_2
+            phase_stop_2 = min(A_lvl.shape, I_lvl_i)
+            if I_lvl_i == phase_stop_2
+                for i_7 = i:phase_stop_2
+                    B_lvl_q = (1 - 1) * A_lvl.shape + i_7
+                    A_lvl_q = (1 - 1) * A_lvl.shape + i_7
+                    s_3 = I_lvl_val[I_lvl_q]
+                    A_lvl_2_q_2 = (A_lvl_q - 1) * A_lvl_2.shape + s_3
+                    A_lvl_3_val_2 = A_lvl_2_val[A_lvl_2_q_2]
+                    B_lvl_val[B_lvl_q] = A_lvl_3_val_2
+                end
+                I_lvl_q += 1
+            else
+                for i_8 = i:phase_stop_2
+                    B_lvl_q = (1 - 1) * A_lvl.shape + i_8
+                    A_lvl_q = (1 - 1) * A_lvl.shape + i_8
+                    s_4 = I_lvl_val[I_lvl_q]
+                    A_lvl_2_q_3 = (A_lvl_q - 1) * A_lvl_2.shape + s_4
+                    A_lvl_3_val_3 = A_lvl_2_val[A_lvl_2_q_3]
+                    B_lvl_val[B_lvl_q] = A_lvl_3_val_3
+                end
             end
+            i = phase_stop_2 + 1
+            break
         end
-        i = phase_stop + 1
     end
     qos = 1 * A_lvl.shape
     resize!(B_lvl_val, qos)

--- a/test/reference64/gather_hl.jl
+++ b/test/reference64/gather_hl.jl
@@ -14,19 +14,24 @@ begin
     end
     phase_stop = min(5, A_lvl_i1)
     if phase_stop >= 5
-        s = 5
         if A_lvl_idx[A_lvl_q] < 5
             A_lvl_q = Finch.scansearch(A_lvl_idx, 5, A_lvl_q, A_lvl_q_stop - 1)
         end
-        while s <= phase_stop
+        while true
             A_lvl_i = A_lvl_idx[A_lvl_q]
-            phase_stop_2 = min(phase_stop, A_lvl_i)
-            if A_lvl_i == phase_stop_2
+            if A_lvl_i < phase_stop
                 A_lvl_2_val = A_lvl_val[A_lvl_q]
                 B_val = A_lvl_2_val + B_val
                 A_lvl_q += 1
+            else
+                phase_stop_3 = min(A_lvl_i, phase_stop)
+                if A_lvl_i == phase_stop_3
+                    A_lvl_2_val = A_lvl_val[A_lvl_q]
+                    B_val = B_val + A_lvl_2_val
+                    A_lvl_q += 1
+                end
+                break
             end
-            s = phase_stop_2 + 1
         end
     end
     (B = (Scalar){0.0, Float64}(B_val),)

--- a/test/reference64/gustavsons.jl
+++ b/test/reference64/gustavsons.jl
@@ -55,16 +55,14 @@ begin
         end
         phase_stop = min(A_lvl_2.shape, A_lvl_2_i1)
         if phase_stop >= 1
-            k = 1
             if A_lvl_idx[A_lvl_2_q] < 1
                 A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
             end
-            while k <= phase_stop
+            while true
                 A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                if A_lvl_2_i == phase_stop_2
+                if A_lvl_2_i < phase_stop
                     A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
-                    A_lvl_q_2 = (1 - 1) * A_lvl.shape + phase_stop_2
+                    A_lvl_q_2 = (1 - 1) * A_lvl.shape + A_lvl_2_i
                     A_lvl_2_q_2 = A_lvl_ptr[A_lvl_q_2]
                     A_lvl_2_q_stop_2 = A_lvl_ptr[A_lvl_q_2 + 1]
                     if A_lvl_2_q_2 < A_lvl_2_q_stop_2
@@ -74,16 +72,14 @@ begin
                     end
                     phase_stop_3 = min(A_lvl_2.shape, A_lvl_2_i1_2)
                     if phase_stop_3 >= 1
-                        i = 1
                         if A_lvl_idx[A_lvl_2_q_2] < 1
                             A_lvl_2_q_2 = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q_2, A_lvl_2_q_stop_2 - 1)
                         end
-                        while i <= phase_stop_3
+                        while true
                             A_lvl_2_i_2 = A_lvl_idx[A_lvl_2_q_2]
-                            phase_stop_4 = min(phase_stop_3, A_lvl_2_i_2)
-                            if A_lvl_2_i_2 == phase_stop_4
+                            if A_lvl_2_i_2 < phase_stop_3
                                 A_lvl_3_val_2 = A_lvl_2_val[A_lvl_2_q_2]
-                                w_lvl_q_2 = (1 - 1) * A_lvl_2.shape + phase_stop_4
+                                w_lvl_q_2 = (1 - 1) * A_lvl_2.shape + A_lvl_2_i_2
                                 w_lvl_val[w_lvl_q_2] = A_lvl_3_val * A_lvl_3_val_2 + w_lvl_val[w_lvl_q_2]
                                 if !(w_lvl_tbl[w_lvl_q_2])
                                     w_lvl_tbl[w_lvl_q_2] = true
@@ -92,16 +88,89 @@ begin
                                         w_lvl_qos_stop = max(w_lvl_qos_stop << 1, 1)
                                         Finch.resize_if_smaller!(w_lvl_srt, w_lvl_qos_stop)
                                     end
-                                    w_lvl_srt[w_lvl_qos_fill] = (1, phase_stop_4)
+                                    w_lvl_srt[w_lvl_qos_fill] = (1, A_lvl_2_i_2)
                                 end
                                 A_lvl_2_q_2 += 1
+                            else
+                                phase_stop_5 = min(A_lvl_2_i_2, phase_stop_3)
+                                if A_lvl_2_i_2 == phase_stop_5
+                                    A_lvl_3_val_2 = A_lvl_2_val[A_lvl_2_q_2]
+                                    w_lvl_q_2 = (1 - 1) * A_lvl_2.shape + phase_stop_5
+                                    w_lvl_val[w_lvl_q_2] = A_lvl_3_val * A_lvl_3_val_2 + w_lvl_val[w_lvl_q_2]
+                                    if !(w_lvl_tbl[w_lvl_q_2])
+                                        w_lvl_tbl[w_lvl_q_2] = true
+                                        w_lvl_qos_fill += 1
+                                        if w_lvl_qos_fill > w_lvl_qos_stop
+                                            w_lvl_qos_stop = max(w_lvl_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(w_lvl_srt, w_lvl_qos_stop)
+                                        end
+                                        w_lvl_srt[w_lvl_qos_fill] = (1, phase_stop_5)
+                                    end
+                                    A_lvl_2_q_2 += 1
+                                end
+                                break
                             end
-                            i = phase_stop_4 + 1
                         end
                     end
                     A_lvl_2_q += 1
+                else
+                    phase_stop_7 = min(A_lvl_2_i, phase_stop)
+                    if A_lvl_2_i == phase_stop_7
+                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                        A_lvl_q_2 = (1 - 1) * A_lvl.shape + phase_stop_7
+                        A_lvl_2_q_3 = A_lvl_ptr[A_lvl_q_2]
+                        A_lvl_2_q_stop_3 = A_lvl_ptr[A_lvl_q_2 + 1]
+                        if A_lvl_2_q_3 < A_lvl_2_q_stop_3
+                            A_lvl_2_i1_3 = A_lvl_idx[A_lvl_2_q_stop_3 - 1]
+                        else
+                            A_lvl_2_i1_3 = 0
+                        end
+                        phase_stop_8 = min(A_lvl_2.shape, A_lvl_2_i1_3)
+                        if phase_stop_8 >= 1
+                            if A_lvl_idx[A_lvl_2_q_3] < 1
+                                A_lvl_2_q_3 = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q_3, A_lvl_2_q_stop_3 - 1)
+                            end
+                            while true
+                                A_lvl_2_i_3 = A_lvl_idx[A_lvl_2_q_3]
+                                if A_lvl_2_i_3 < phase_stop_8
+                                    A_lvl_3_val_3 = A_lvl_2_val[A_lvl_2_q_3]
+                                    w_lvl_q_2 = (1 - 1) * A_lvl_2.shape + A_lvl_2_i_3
+                                    w_lvl_val[w_lvl_q_2] = A_lvl_3_val * A_lvl_3_val_3 + w_lvl_val[w_lvl_q_2]
+                                    if !(w_lvl_tbl[w_lvl_q_2])
+                                        w_lvl_tbl[w_lvl_q_2] = true
+                                        w_lvl_qos_fill += 1
+                                        if w_lvl_qos_fill > w_lvl_qos_stop
+                                            w_lvl_qos_stop = max(w_lvl_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(w_lvl_srt, w_lvl_qos_stop)
+                                        end
+                                        w_lvl_srt[w_lvl_qos_fill] = (1, A_lvl_2_i_3)
+                                    end
+                                    A_lvl_2_q_3 += 1
+                                else
+                                    phase_stop_10 = min(A_lvl_2_i_3, phase_stop_8)
+                                    if A_lvl_2_i_3 == phase_stop_10
+                                        A_lvl_3_val_3 = A_lvl_2_val[A_lvl_2_q_3]
+                                        w_lvl_q_2 = (1 - 1) * A_lvl_2.shape + phase_stop_10
+                                        w_lvl_val[w_lvl_q_2] = A_lvl_3_val * A_lvl_3_val_3 + w_lvl_val[w_lvl_q_2]
+                                        if !(w_lvl_tbl[w_lvl_q_2])
+                                            w_lvl_tbl[w_lvl_q_2] = true
+                                            w_lvl_qos_fill += 1
+                                            if w_lvl_qos_fill > w_lvl_qos_stop
+                                                w_lvl_qos_stop = max(w_lvl_qos_stop << 1, 1)
+                                                Finch.resize_if_smaller!(w_lvl_srt, w_lvl_qos_stop)
+                                            end
+                                            w_lvl_srt[w_lvl_qos_fill] = (1, phase_stop_10)
+                                        end
+                                        A_lvl_2_q_3 += 1
+                                    end
+                                    break
+                                end
+                            end
+                        end
+                        A_lvl_2_q += 1
+                    end
+                    break
                 end
-                k = phase_stop_2 + 1
             end
         end
         sort!(view(w_lvl_srt, 1:w_lvl_qos_fill))
@@ -124,16 +193,14 @@ begin
         else
             w_lvl_i_stop = 0
         end
-        phase_stop_7 = min(A_lvl_2.shape, w_lvl_i_stop)
-        if phase_stop_7 >= 1
-            i_2 = 1
+        phase_stop_13 = min(A_lvl_2.shape, w_lvl_i_stop)
+        if phase_stop_13 >= 1
             while w_lvl_r_3 + 1 < w_lvl_r_stop && last(w_lvl_srt[w_lvl_r_3]) < 1
                 w_lvl_r_3 += 1
             end
-            while i_2 <= phase_stop_7
+            while true
                 w_lvl_i_2 = last(w_lvl_srt[w_lvl_r_3])
-                phase_stop_8 = min(phase_stop_7, w_lvl_i_2)
-                if w_lvl_i_2 == phase_stop_8
+                if w_lvl_i_2 < phase_stop_13
                     w_lvl_q_3 = (1 - 1) * A_lvl_2.shape + w_lvl_i_2
                     w_lvl_2_val = w_lvl_val[w_lvl_q_3]
                     if B_lvl_2_qos > B_lvl_2_qos_stop
@@ -143,12 +210,29 @@ begin
                         Finch.fill_range!(B_lvl_2_val, 0.0, B_lvl_2_qos, B_lvl_2_qos_stop)
                     end
                     B_lvl_2_val[B_lvl_2_qos] = w_lvl_2_val
-                    B_lvl_idx[B_lvl_2_qos] = phase_stop_8
+                    B_lvl_idx[B_lvl_2_qos] = w_lvl_i_2
                     B_lvl_2_qos += 1
                     B_lvl_2_prev_pos = B_lvl_q
                     w_lvl_r_3 += 1
+                else
+                    phase_stop_15 = min(w_lvl_i_2, phase_stop_13)
+                    if w_lvl_i_2 == phase_stop_15
+                        w_lvl_q_3 = (1 - 1) * A_lvl_2.shape + w_lvl_i_2
+                        w_lvl_2_val_2 = w_lvl_val[w_lvl_q_3]
+                        if B_lvl_2_qos > B_lvl_2_qos_stop
+                            B_lvl_2_qos_stop = max(B_lvl_2_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(B_lvl_idx, B_lvl_2_qos_stop)
+                            Finch.resize_if_smaller!(B_lvl_2_val, B_lvl_2_qos_stop)
+                            Finch.fill_range!(B_lvl_2_val, 0.0, B_lvl_2_qos, B_lvl_2_qos_stop)
+                        end
+                        B_lvl_2_val[B_lvl_2_qos] = w_lvl_2_val_2
+                        B_lvl_idx[B_lvl_2_qos] = phase_stop_15
+                        B_lvl_2_qos += 1
+                        B_lvl_2_prev_pos = B_lvl_q
+                        w_lvl_r_3 += 1
+                    end
+                    break
                 end
-                i_2 = phase_stop_8 + 1
             end
         end
         B_lvl_ptr[B_lvl_q + 1] = (B_lvl_2_qos - B_lvl_2_qos_fill) - 1

--- a/test/reference64/increment_to_10×10 Fiber!(Dense(SparseByteMap(Element(0.0)))).jl
+++ b/test/reference64/increment_to_10×10 Fiber!(Dense(SparseByteMap(Element(0.0)))).jl
@@ -23,19 +23,17 @@ begin
     end
     phase_stop = min(arr_2_lvl.shape[2], arr_2_lvl_i_stop)
     if phase_stop >= 1
-        j = 1
         if arr_2_lvl_tbl2[arr_2_lvl_q] < 1
             arr_2_lvl_q = Finch.scansearch(arr_2_lvl_tbl2, 1, arr_2_lvl_q, arr_2_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             arr_2_lvl_i = arr_2_lvl_tbl2[arr_2_lvl_q]
             arr_2_lvl_q_step = arr_2_lvl_q
             if arr_2_lvl_tbl2[arr_2_lvl_q] == arr_2_lvl_i
                 arr_2_lvl_q_step = Finch.scansearch(arr_2_lvl_tbl2, arr_2_lvl_i + 1, arr_2_lvl_q, arr_2_lvl_q_stop - 1)
             end
-            phase_stop_2 = min(phase_stop, arr_2_lvl_i)
-            if arr_2_lvl_i == phase_stop_2
-                fmt_lvl_q = (1 - 1) * fmt_lvl.shape + phase_stop_2
+            if arr_2_lvl_i < phase_stop
+                fmt_lvl_q = (1 - 1) * fmt_lvl.shape + arr_2_lvl_i
                 arr_2_lvl_q_2 = arr_2_lvl_q
                 if arr_2_lvl_q < arr_2_lvl_q_step
                     arr_2_lvl_i_stop_2 = arr_2_lvl_tbl1[arr_2_lvl_q_step - 1]
@@ -44,16 +42,14 @@ begin
                 end
                 phase_stop_3 = min(arr_2_lvl.shape[1], arr_2_lvl_i_stop_2)
                 if phase_stop_3 >= 1
-                    i = 1
                     if arr_2_lvl_tbl1[arr_2_lvl_q] < 1
                         arr_2_lvl_q_2 = Finch.scansearch(arr_2_lvl_tbl1, 1, arr_2_lvl_q, arr_2_lvl_q_step - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         arr_2_lvl_i_2 = arr_2_lvl_tbl1[arr_2_lvl_q_2]
-                        phase_stop_4 = min(phase_stop_3, arr_2_lvl_i_2)
-                        if arr_2_lvl_i_2 == phase_stop_4
+                        if arr_2_lvl_i_2 < phase_stop_3
                             arr_2_lvl_2_val = arr_2_lvl_val[arr_2_lvl_q_2]
-                            fmt_lvl_2_q = (fmt_lvl_q - 1) * fmt_lvl_2.shape + phase_stop_4
+                            fmt_lvl_2_q = (fmt_lvl_q - 1) * fmt_lvl_2.shape + arr_2_lvl_i_2
                             fmt_lvl_2_val[fmt_lvl_2_q] = arr_2_lvl_2_val + fmt_lvl_2_val[fmt_lvl_2_q]
                             if !(fmt_lvl_tbl[fmt_lvl_2_q])
                                 fmt_lvl_tbl[fmt_lvl_2_q] = true
@@ -62,16 +58,87 @@ begin
                                     fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
                                     Finch.resize_if_smaller!(fmt_lvl_srt, fmt_lvl_2_qos_stop)
                                 end
-                                fmt_lvl_srt[fmt_lvl_2_qos_fill] = (fmt_lvl_q, phase_stop_4)
+                                fmt_lvl_srt[fmt_lvl_2_qos_fill] = (fmt_lvl_q, arr_2_lvl_i_2)
                             end
                             arr_2_lvl_q_2 += 1
+                        else
+                            phase_stop_5 = min(arr_2_lvl_i_2, phase_stop_3)
+                            if arr_2_lvl_i_2 == phase_stop_5
+                                arr_2_lvl_2_val = arr_2_lvl_val[arr_2_lvl_q_2]
+                                fmt_lvl_2_q = (fmt_lvl_q - 1) * fmt_lvl_2.shape + phase_stop_5
+                                fmt_lvl_2_val[fmt_lvl_2_q] = arr_2_lvl_2_val + fmt_lvl_2_val[fmt_lvl_2_q]
+                                if !(fmt_lvl_tbl[fmt_lvl_2_q])
+                                    fmt_lvl_tbl[fmt_lvl_2_q] = true
+                                    fmt_lvl_2_qos_fill += 1
+                                    if fmt_lvl_2_qos_fill > fmt_lvl_2_qos_stop
+                                        fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(fmt_lvl_srt, fmt_lvl_2_qos_stop)
+                                    end
+                                    fmt_lvl_srt[fmt_lvl_2_qos_fill] = (fmt_lvl_q, phase_stop_5)
+                                end
+                                arr_2_lvl_q_2 += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 arr_2_lvl_q = arr_2_lvl_q_step
+            else
+                phase_stop_7 = min(arr_2_lvl_i, phase_stop)
+                if arr_2_lvl_i == phase_stop_7
+                    fmt_lvl_q = (1 - 1) * fmt_lvl.shape + phase_stop_7
+                    arr_2_lvl_q_2 = arr_2_lvl_q
+                    if arr_2_lvl_q < arr_2_lvl_q_step
+                        arr_2_lvl_i_stop_2 = arr_2_lvl_tbl1[arr_2_lvl_q_step - 1]
+                    else
+                        arr_2_lvl_i_stop_2 = 0
+                    end
+                    phase_stop_8 = min(arr_2_lvl.shape[1], arr_2_lvl_i_stop_2)
+                    if phase_stop_8 >= 1
+                        if arr_2_lvl_tbl1[arr_2_lvl_q] < 1
+                            arr_2_lvl_q_2 = Finch.scansearch(arr_2_lvl_tbl1, 1, arr_2_lvl_q, arr_2_lvl_q_step - 1)
+                        end
+                        while true
+                            arr_2_lvl_i_2 = arr_2_lvl_tbl1[arr_2_lvl_q_2]
+                            if arr_2_lvl_i_2 < phase_stop_8
+                                arr_2_lvl_2_val_2 = arr_2_lvl_val[arr_2_lvl_q_2]
+                                fmt_lvl_2_q_2 = (fmt_lvl_q - 1) * fmt_lvl_2.shape + arr_2_lvl_i_2
+                                fmt_lvl_2_val[fmt_lvl_2_q_2] = arr_2_lvl_2_val_2 + fmt_lvl_2_val[fmt_lvl_2_q_2]
+                                if !(fmt_lvl_tbl[fmt_lvl_2_q_2])
+                                    fmt_lvl_tbl[fmt_lvl_2_q_2] = true
+                                    fmt_lvl_2_qos_fill += 1
+                                    if fmt_lvl_2_qos_fill > fmt_lvl_2_qos_stop
+                                        fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(fmt_lvl_srt, fmt_lvl_2_qos_stop)
+                                    end
+                                    fmt_lvl_srt[fmt_lvl_2_qos_fill] = (fmt_lvl_q, arr_2_lvl_i_2)
+                                end
+                                arr_2_lvl_q_2 += 1
+                            else
+                                phase_stop_10 = min(arr_2_lvl_i_2, phase_stop_8)
+                                if arr_2_lvl_i_2 == phase_stop_10
+                                    arr_2_lvl_2_val_2 = arr_2_lvl_val[arr_2_lvl_q_2]
+                                    fmt_lvl_2_q_2 = (fmt_lvl_q - 1) * fmt_lvl_2.shape + phase_stop_10
+                                    fmt_lvl_2_val[fmt_lvl_2_q_2] = arr_2_lvl_2_val_2 + fmt_lvl_2_val[fmt_lvl_2_q_2]
+                                    if !(fmt_lvl_tbl[fmt_lvl_2_q_2])
+                                        fmt_lvl_tbl[fmt_lvl_2_q_2] = true
+                                        fmt_lvl_2_qos_fill += 1
+                                        if fmt_lvl_2_qos_fill > fmt_lvl_2_qos_stop
+                                            fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
+                                            Finch.resize_if_smaller!(fmt_lvl_srt, fmt_lvl_2_qos_stop)
+                                        end
+                                        fmt_lvl_srt[fmt_lvl_2_qos_fill] = (fmt_lvl_q, phase_stop_10)
+                                    end
+                                    arr_2_lvl_q_2 += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    arr_2_lvl_q = arr_2_lvl_q_step
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     sort!(view(fmt_lvl_srt, 1:fmt_lvl_2_qos_fill))

--- a/test/reference64/increment_to_10×10 Fiber!(Dense(SparseHash{1}(Element(0.0)))).jl
+++ b/test/reference64/increment_to_10×10 Fiber!(Dense(SparseHash{1}(Element(0.0)))).jl
@@ -29,19 +29,17 @@ begin
     end
     phase_stop = min(arr_2_lvl.shape[2], arr_2_lvl_i_stop)
     if phase_stop >= 1
-        j = 1
         if arr_2_lvl_tbl2[arr_2_lvl_q] < 1
             arr_2_lvl_q = Finch.scansearch(arr_2_lvl_tbl2, 1, arr_2_lvl_q, arr_2_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             arr_2_lvl_i = arr_2_lvl_tbl2[arr_2_lvl_q]
             arr_2_lvl_q_step = arr_2_lvl_q
             if arr_2_lvl_tbl2[arr_2_lvl_q] == arr_2_lvl_i
                 arr_2_lvl_q_step = Finch.scansearch(arr_2_lvl_tbl2, arr_2_lvl_i + 1, arr_2_lvl_q, arr_2_lvl_q_stop - 1)
             end
-            phase_stop_2 = min(phase_stop, arr_2_lvl_i)
-            if arr_2_lvl_i == phase_stop_2
-                fmt_lvl_q = (1 - 1) * fmt_lvl.shape + phase_stop_2
+            if arr_2_lvl_i < phase_stop
+                fmt_lvl_q = (1 - 1) * fmt_lvl.shape + arr_2_lvl_i
                 arr_2_lvl_q_2 = arr_2_lvl_q
                 if arr_2_lvl_q < arr_2_lvl_q_step
                     arr_2_lvl_i_stop_2 = arr_2_lvl_tbl1[arr_2_lvl_q_step - 1]
@@ -50,16 +48,14 @@ begin
                 end
                 phase_stop_3 = min(arr_2_lvl.shape[1], arr_2_lvl_i_stop_2)
                 if phase_stop_3 >= 1
-                    i = 1
                     if arr_2_lvl_tbl1[arr_2_lvl_q] < 1
                         arr_2_lvl_q_2 = Finch.scansearch(arr_2_lvl_tbl1, 1, arr_2_lvl_q, arr_2_lvl_q_step - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         arr_2_lvl_i_2 = arr_2_lvl_tbl1[arr_2_lvl_q_2]
-                        phase_stop_4 = min(phase_stop_3, arr_2_lvl_i_2)
-                        if arr_2_lvl_i_2 == phase_stop_4
+                        if arr_2_lvl_i_2 < phase_stop_3
                             arr_2_lvl_2_val = arr_2_lvl_val[arr_2_lvl_q_2]
-                            fmt_lvl_2_key = (fmt_lvl_q, (phase_stop_4,))
+                            fmt_lvl_2_key = (fmt_lvl_q, (arr_2_lvl_i_2,))
                             fmt_lvl_2_q = get(fmt_lvl_tbl, fmt_lvl_2_key, fmt_lvl_2_qos_fill + 1)
                             if fmt_lvl_2_q > fmt_lvl_2_qos_stop
                                 fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
@@ -73,13 +69,90 @@ begin
                                 fmt_lvl_ptr[fmt_lvl_q + 1] += 1
                             end
                             arr_2_lvl_q_2 += 1
+                        else
+                            phase_stop_5 = min(arr_2_lvl_i_2, phase_stop_3)
+                            if arr_2_lvl_i_2 == phase_stop_5
+                                arr_2_lvl_2_val = arr_2_lvl_val[arr_2_lvl_q_2]
+                                fmt_lvl_2_key = (fmt_lvl_q, (phase_stop_5,))
+                                fmt_lvl_2_q = get(fmt_lvl_tbl, fmt_lvl_2_key, fmt_lvl_2_qos_fill + 1)
+                                if fmt_lvl_2_q > fmt_lvl_2_qos_stop
+                                    fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(fmt_lvl_2_val, fmt_lvl_2_qos_stop)
+                                    Finch.fill_range!(fmt_lvl_2_val, 0.0, fmt_lvl_2_q, fmt_lvl_2_qos_stop)
+                                end
+                                fmt_lvl_2_val[fmt_lvl_2_q] = arr_2_lvl_2_val + fmt_lvl_2_val[fmt_lvl_2_q]
+                                if fmt_lvl_2_q > fmt_lvl_2_qos_fill
+                                    fmt_lvl_2_qos_fill = fmt_lvl_2_q
+                                    fmt_lvl_tbl[fmt_lvl_2_key] = fmt_lvl_2_q
+                                    fmt_lvl_ptr[fmt_lvl_q + 1] += 1
+                                end
+                                arr_2_lvl_q_2 += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 arr_2_lvl_q = arr_2_lvl_q_step
+            else
+                phase_stop_7 = min(arr_2_lvl_i, phase_stop)
+                if arr_2_lvl_i == phase_stop_7
+                    fmt_lvl_q = (1 - 1) * fmt_lvl.shape + phase_stop_7
+                    arr_2_lvl_q_2 = arr_2_lvl_q
+                    if arr_2_lvl_q < arr_2_lvl_q_step
+                        arr_2_lvl_i_stop_2 = arr_2_lvl_tbl1[arr_2_lvl_q_step - 1]
+                    else
+                        arr_2_lvl_i_stop_2 = 0
+                    end
+                    phase_stop_8 = min(arr_2_lvl.shape[1], arr_2_lvl_i_stop_2)
+                    if phase_stop_8 >= 1
+                        if arr_2_lvl_tbl1[arr_2_lvl_q] < 1
+                            arr_2_lvl_q_2 = Finch.scansearch(arr_2_lvl_tbl1, 1, arr_2_lvl_q, arr_2_lvl_q_step - 1)
+                        end
+                        while true
+                            arr_2_lvl_i_2 = arr_2_lvl_tbl1[arr_2_lvl_q_2]
+                            if arr_2_lvl_i_2 < phase_stop_8
+                                arr_2_lvl_2_val_2 = arr_2_lvl_val[arr_2_lvl_q_2]
+                                fmt_lvl_2_key_2 = (fmt_lvl_q, (arr_2_lvl_i_2,))
+                                fmt_lvl_2_q_2 = get(fmt_lvl_tbl, fmt_lvl_2_key_2, fmt_lvl_2_qos_fill + 1)
+                                if fmt_lvl_2_q_2 > fmt_lvl_2_qos_stop
+                                    fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(fmt_lvl_2_val, fmt_lvl_2_qos_stop)
+                                    Finch.fill_range!(fmt_lvl_2_val, 0.0, fmt_lvl_2_q_2, fmt_lvl_2_qos_stop)
+                                end
+                                fmt_lvl_2_val[fmt_lvl_2_q_2] = arr_2_lvl_2_val_2 + fmt_lvl_2_val[fmt_lvl_2_q_2]
+                                if fmt_lvl_2_q_2 > fmt_lvl_2_qos_fill
+                                    fmt_lvl_2_qos_fill = fmt_lvl_2_q_2
+                                    fmt_lvl_tbl[fmt_lvl_2_key_2] = fmt_lvl_2_q_2
+                                    fmt_lvl_ptr[fmt_lvl_q + 1] += 1
+                                end
+                                arr_2_lvl_q_2 += 1
+                            else
+                                phase_stop_10 = min(arr_2_lvl_i_2, phase_stop_8)
+                                if arr_2_lvl_i_2 == phase_stop_10
+                                    arr_2_lvl_2_val_2 = arr_2_lvl_val[arr_2_lvl_q_2]
+                                    fmt_lvl_2_key_2 = (fmt_lvl_q, (phase_stop_10,))
+                                    fmt_lvl_2_q_2 = get(fmt_lvl_tbl, fmt_lvl_2_key_2, fmt_lvl_2_qos_fill + 1)
+                                    if fmt_lvl_2_q_2 > fmt_lvl_2_qos_stop
+                                        fmt_lvl_2_qos_stop = max(fmt_lvl_2_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(fmt_lvl_2_val, fmt_lvl_2_qos_stop)
+                                        Finch.fill_range!(fmt_lvl_2_val, 0.0, fmt_lvl_2_q_2, fmt_lvl_2_qos_stop)
+                                    end
+                                    fmt_lvl_2_val[fmt_lvl_2_q_2] = arr_2_lvl_2_val_2 + fmt_lvl_2_val[fmt_lvl_2_q_2]
+                                    if fmt_lvl_2_q_2 > fmt_lvl_2_qos_fill
+                                        fmt_lvl_2_qos_fill = fmt_lvl_2_q_2
+                                        fmt_lvl_tbl[fmt_lvl_2_key_2] = fmt_lvl_2_q_2
+                                        fmt_lvl_ptr[fmt_lvl_q + 1] += 1
+                                    end
+                                    arr_2_lvl_q_2 += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    arr_2_lvl_q = arr_2_lvl_q_step
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     resize!(fmt_lvl_srt, length(fmt_lvl_tbl))

--- a/test/reference64/increment_to_10×10 Fiber!(SparseHash{2}(Element(0.0))).jl
+++ b/test/reference64/increment_to_10×10 Fiber!(SparseHash{2}(Element(0.0))).jl
@@ -28,18 +28,16 @@ begin
     end
     phase_stop = min(arr_2_lvl.shape[2], arr_2_lvl_i_stop)
     if phase_stop >= 1
-        j = 1
         if arr_2_lvl_tbl2[arr_2_lvl_q] < 1
             arr_2_lvl_q = Finch.scansearch(arr_2_lvl_tbl2, 1, arr_2_lvl_q, arr_2_lvl_q_stop - 1)
         end
-        while j <= phase_stop
+        while true
             arr_2_lvl_i = arr_2_lvl_tbl2[arr_2_lvl_q]
             arr_2_lvl_q_step = arr_2_lvl_q
             if arr_2_lvl_tbl2[arr_2_lvl_q] == arr_2_lvl_i
                 arr_2_lvl_q_step = Finch.scansearch(arr_2_lvl_tbl2, arr_2_lvl_i + 1, arr_2_lvl_q, arr_2_lvl_q_stop - 1)
             end
-            phase_stop_2 = min(phase_stop, arr_2_lvl_i)
-            if arr_2_lvl_i == phase_stop_2
+            if arr_2_lvl_i < phase_stop
                 arr_2_lvl_q_2 = arr_2_lvl_q
                 if arr_2_lvl_q < arr_2_lvl_q_step
                     arr_2_lvl_i_stop_2 = arr_2_lvl_tbl1[arr_2_lvl_q_step - 1]
@@ -48,16 +46,14 @@ begin
                 end
                 phase_stop_3 = min(arr_2_lvl.shape[1], arr_2_lvl_i_stop_2)
                 if phase_stop_3 >= 1
-                    i = 1
                     if arr_2_lvl_tbl1[arr_2_lvl_q] < 1
                         arr_2_lvl_q_2 = Finch.scansearch(arr_2_lvl_tbl1, 1, arr_2_lvl_q, arr_2_lvl_q_step - 1)
                     end
-                    while i <= phase_stop_3
+                    while true
                         arr_2_lvl_i_2 = arr_2_lvl_tbl1[arr_2_lvl_q_2]
-                        phase_stop_4 = min(phase_stop_3, arr_2_lvl_i_2)
-                        if arr_2_lvl_i_2 == phase_stop_4
+                        if arr_2_lvl_i_2 < phase_stop_3
                             arr_2_lvl_2_val = arr_2_lvl_val[arr_2_lvl_q_2]
-                            fmt_lvl_key_2 = (1, (phase_stop_4, phase_stop_2))
+                            fmt_lvl_key_2 = (1, (arr_2_lvl_i_2, arr_2_lvl_i))
                             fmt_lvl_q_2 = get(fmt_lvl_tbl, fmt_lvl_key_2, fmt_lvl_qos_fill + 1)
                             if fmt_lvl_q_2 > fmt_lvl_qos_stop
                                 fmt_lvl_qos_stop = max(fmt_lvl_qos_stop << 1, 1)
@@ -71,13 +67,89 @@ begin
                                 fmt_lvl_ptr[1 + 1] += 1
                             end
                             arr_2_lvl_q_2 += 1
+                        else
+                            phase_stop_5 = min(arr_2_lvl_i_2, phase_stop_3)
+                            if arr_2_lvl_i_2 == phase_stop_5
+                                arr_2_lvl_2_val = arr_2_lvl_val[arr_2_lvl_q_2]
+                                fmt_lvl_key_2 = (1, (phase_stop_5, arr_2_lvl_i))
+                                fmt_lvl_q_2 = get(fmt_lvl_tbl, fmt_lvl_key_2, fmt_lvl_qos_fill + 1)
+                                if fmt_lvl_q_2 > fmt_lvl_qos_stop
+                                    fmt_lvl_qos_stop = max(fmt_lvl_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(fmt_lvl_val, fmt_lvl_qos_stop)
+                                    Finch.fill_range!(fmt_lvl_val, 0.0, fmt_lvl_q_2, fmt_lvl_qos_stop)
+                                end
+                                fmt_lvl_val[fmt_lvl_q_2] = arr_2_lvl_2_val + fmt_lvl_val[fmt_lvl_q_2]
+                                if fmt_lvl_q_2 > fmt_lvl_qos_fill
+                                    fmt_lvl_qos_fill = fmt_lvl_q_2
+                                    fmt_lvl_tbl[fmt_lvl_key_2] = fmt_lvl_q_2
+                                    fmt_lvl_ptr[1 + 1] += 1
+                                end
+                                arr_2_lvl_q_2 += 1
+                            end
+                            break
                         end
-                        i = phase_stop_4 + 1
                     end
                 end
                 arr_2_lvl_q = arr_2_lvl_q_step
+            else
+                phase_stop_7 = min(arr_2_lvl_i, phase_stop)
+                if arr_2_lvl_i == phase_stop_7
+                    arr_2_lvl_q_2 = arr_2_lvl_q
+                    if arr_2_lvl_q < arr_2_lvl_q_step
+                        arr_2_lvl_i_stop_2 = arr_2_lvl_tbl1[arr_2_lvl_q_step - 1]
+                    else
+                        arr_2_lvl_i_stop_2 = 0
+                    end
+                    phase_stop_8 = min(arr_2_lvl.shape[1], arr_2_lvl_i_stop_2)
+                    if phase_stop_8 >= 1
+                        if arr_2_lvl_tbl1[arr_2_lvl_q] < 1
+                            arr_2_lvl_q_2 = Finch.scansearch(arr_2_lvl_tbl1, 1, arr_2_lvl_q, arr_2_lvl_q_step - 1)
+                        end
+                        while true
+                            arr_2_lvl_i_2 = arr_2_lvl_tbl1[arr_2_lvl_q_2]
+                            if arr_2_lvl_i_2 < phase_stop_8
+                                arr_2_lvl_2_val_2 = arr_2_lvl_val[arr_2_lvl_q_2]
+                                fmt_lvl_key_3 = (1, (arr_2_lvl_i_2, phase_stop_7))
+                                fmt_lvl_q_3 = get(fmt_lvl_tbl, fmt_lvl_key_3, fmt_lvl_qos_fill + 1)
+                                if fmt_lvl_q_3 > fmt_lvl_qos_stop
+                                    fmt_lvl_qos_stop = max(fmt_lvl_qos_stop << 1, 1)
+                                    Finch.resize_if_smaller!(fmt_lvl_val, fmt_lvl_qos_stop)
+                                    Finch.fill_range!(fmt_lvl_val, 0.0, fmt_lvl_q_3, fmt_lvl_qos_stop)
+                                end
+                                fmt_lvl_val[fmt_lvl_q_3] = arr_2_lvl_2_val_2 + fmt_lvl_val[fmt_lvl_q_3]
+                                if fmt_lvl_q_3 > fmt_lvl_qos_fill
+                                    fmt_lvl_qos_fill = fmt_lvl_q_3
+                                    fmt_lvl_tbl[fmt_lvl_key_3] = fmt_lvl_q_3
+                                    fmt_lvl_ptr[1 + 1] += 1
+                                end
+                                arr_2_lvl_q_2 += 1
+                            else
+                                phase_stop_10 = min(arr_2_lvl_i_2, phase_stop_8)
+                                if arr_2_lvl_i_2 == phase_stop_10
+                                    arr_2_lvl_2_val_2 = arr_2_lvl_val[arr_2_lvl_q_2]
+                                    fmt_lvl_key_3 = (1, (phase_stop_10, phase_stop_7))
+                                    fmt_lvl_q_3 = get(fmt_lvl_tbl, fmt_lvl_key_3, fmt_lvl_qos_fill + 1)
+                                    if fmt_lvl_q_3 > fmt_lvl_qos_stop
+                                        fmt_lvl_qos_stop = max(fmt_lvl_qos_stop << 1, 1)
+                                        Finch.resize_if_smaller!(fmt_lvl_val, fmt_lvl_qos_stop)
+                                        Finch.fill_range!(fmt_lvl_val, 0.0, fmt_lvl_q_3, fmt_lvl_qos_stop)
+                                    end
+                                    fmt_lvl_val[fmt_lvl_q_3] = arr_2_lvl_2_val_2 + fmt_lvl_val[fmt_lvl_q_3]
+                                    if fmt_lvl_q_3 > fmt_lvl_qos_fill
+                                        fmt_lvl_qos_fill = fmt_lvl_q_3
+                                        fmt_lvl_tbl[fmt_lvl_key_3] = fmt_lvl_q_3
+                                        fmt_lvl_ptr[1 + 1] += 1
+                                    end
+                                    arr_2_lvl_q_2 += 1
+                                end
+                                break
+                            end
+                        end
+                    end
+                    arr_2_lvl_q = arr_2_lvl_q_step
+                end
+                break
             end
-            j = phase_stop_2 + 1
         end
     end
     resize!(fmt_lvl_srt, length(fmt_lvl_tbl))

--- a/test/reference64/parallel_blur_sparse.jl
+++ b/test/reference64/parallel_blur_sparse.jl
@@ -197,98 +197,118 @@ begin
                     phase_start_9 = max(1, 1 + input_lvl_2_i1_2, 2 + input_lvl_2_i1)
                     phase_stop_9 = min(input_lvl_2.shape, -1 + input_lvl_2_i1_3)
                     if phase_stop_9 >= phase_start_9
-                        x = phase_start_9
                         if input_lvl_idx[input_lvl_2_q_3] < phase_start_9 + 1
                             input_lvl_2_q_3 = Finch.scansearch(input_lvl_idx, phase_start_9 + 1, input_lvl_2_q_3, input_lvl_2_q_stop_3 - 1)
                         end
-                        while x <= phase_stop_9
+                        while true
                             input_lvl_2_i_3 = input_lvl_idx[input_lvl_2_q_3]
-                            phase_stop_10 = min(-1 + input_lvl_2_i_3, phase_stop_9)
-                            if input_lvl_2_i_3 == phase_stop_10 + 1
+                            phase_stop_10 = -1 + input_lvl_2_i_3
+                            if phase_stop_10 < phase_stop_9
                                 input_lvl_3_val_8 = input_lvl_2_val[input_lvl_2_q_3]
                                 tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_10
                                 tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_8 + tmp_lvl_val[tmp_lvl_q]
                                 input_lvl_2_q_3 += 1
+                            else
+                                phase_stop_11 = min(-1 + input_lvl_2_i_3, phase_stop_9)
+                                if input_lvl_2_i_3 == phase_stop_11 + 1
+                                    input_lvl_3_val_8 = input_lvl_2_val[input_lvl_2_q_3]
+                                    tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_11
+                                    tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_8 + tmp_lvl_val[tmp_lvl_q]
+                                    input_lvl_2_q_3 += 1
+                                end
+                                break
                             end
-                            x = phase_stop_10 + 1
                         end
                     end
-                    phase_start_11 = max(1, input_lvl_2_i1_3)
-                    phase_stop_11 = min(input_lvl_2.shape, input_lvl_2_i1_2, 1 + input_lvl_2_i1)
-                    if phase_stop_11 >= phase_start_11
-                        x = phase_start_11
-                        if input_lvl_idx[input_lvl_2_q_2] < phase_start_11
-                            input_lvl_2_q_2 = Finch.scansearch(input_lvl_idx, phase_start_11, input_lvl_2_q_2, input_lvl_2_q_stop_2 - 1)
+                    phase_start_12 = max(1, input_lvl_2_i1_3)
+                    phase_stop_12 = min(input_lvl_2.shape, input_lvl_2_i1_2, 1 + input_lvl_2_i1)
+                    if phase_stop_12 >= phase_start_12
+                        x = phase_start_12
+                        if input_lvl_idx[input_lvl_2_q_2] < phase_start_12
+                            input_lvl_2_q_2 = Finch.scansearch(input_lvl_idx, phase_start_12, input_lvl_2_q_2, input_lvl_2_q_stop_2 - 1)
                         end
-                        if input_lvl_idx[input_lvl_2_q] < phase_start_11 + -1
-                            input_lvl_2_q = Finch.scansearch(input_lvl_idx, phase_start_11 + -1, input_lvl_2_q, input_lvl_2_q_stop - 1)
+                        if input_lvl_idx[input_lvl_2_q] < phase_start_12 + -1
+                            input_lvl_2_q = Finch.scansearch(input_lvl_idx, phase_start_12 + -1, input_lvl_2_q, input_lvl_2_q_stop - 1)
                         end
-                        while x <= phase_stop_11
+                        while x <= phase_stop_12
                             input_lvl_2_i_2 = input_lvl_idx[input_lvl_2_q_2]
                             input_lvl_2_i = input_lvl_idx[input_lvl_2_q]
-                            phase_stop_12 = min(input_lvl_2_i_2, 1 + input_lvl_2_i, phase_stop_11)
-                            if input_lvl_2_i_2 == phase_stop_12 && input_lvl_2_i == phase_stop_12 + -1
+                            phase_stop_13 = min(input_lvl_2_i_2, 1 + input_lvl_2_i, phase_stop_12)
+                            if input_lvl_2_i_2 == phase_stop_13 && input_lvl_2_i == phase_stop_13 + -1
                                 input_lvl_3_val_9 = input_lvl_2_val[input_lvl_2_q]
                                 input_lvl_3_val_10 = input_lvl_2_val[input_lvl_2_q_2]
-                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_12
+                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_13
                                 tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_9 + tmp_lvl_val[tmp_lvl_q] + input_lvl_3_val_10
                                 input_lvl_2_q_2 += 1
                                 input_lvl_2_q += 1
-                            elseif input_lvl_2_i == phase_stop_12 + -1
+                            elseif input_lvl_2_i == phase_stop_13 + -1
                                 input_lvl_3_val_9 = input_lvl_2_val[input_lvl_2_q]
-                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_12
+                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_13
                                 tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_9 + tmp_lvl_val[tmp_lvl_q]
                                 input_lvl_2_q += 1
-                            elseif input_lvl_2_i_2 == phase_stop_12
+                            elseif input_lvl_2_i_2 == phase_stop_13
                                 input_lvl_3_val_10 = input_lvl_2_val[input_lvl_2_q_2]
-                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_12
+                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_13
                                 tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_10 + tmp_lvl_val[tmp_lvl_q]
                                 input_lvl_2_q_2 += 1
                             end
-                            x = phase_stop_12 + 1
+                            x = phase_stop_13 + 1
                         end
                     end
-                    phase_start_13 = max(1, input_lvl_2_i1_3, 2 + input_lvl_2_i1)
-                    phase_stop_13 = min(input_lvl_2.shape, input_lvl_2_i1_2)
-                    if phase_stop_13 >= phase_start_13
-                        x = phase_start_13
-                        if input_lvl_idx[input_lvl_2_q_2] < phase_start_13
-                            input_lvl_2_q_2 = Finch.scansearch(input_lvl_idx, phase_start_13, input_lvl_2_q_2, input_lvl_2_q_stop_2 - 1)
+                    phase_start_14 = max(1, input_lvl_2_i1_3, 2 + input_lvl_2_i1)
+                    phase_stop_14 = min(input_lvl_2.shape, input_lvl_2_i1_2)
+                    if phase_stop_14 >= phase_start_14
+                        if input_lvl_idx[input_lvl_2_q_2] < phase_start_14
+                            input_lvl_2_q_2 = Finch.scansearch(input_lvl_idx, phase_start_14, input_lvl_2_q_2, input_lvl_2_q_stop_2 - 1)
                         end
-                        while x <= phase_stop_13
+                        while true
                             input_lvl_2_i_2 = input_lvl_idx[input_lvl_2_q_2]
-                            phase_stop_14 = min(input_lvl_2_i_2, phase_stop_13)
-                            if input_lvl_2_i_2 == phase_stop_14
+                            if input_lvl_2_i_2 < phase_stop_14
                                 input_lvl_3_val_11 = input_lvl_2_val[input_lvl_2_q_2]
-                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_14
+                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + input_lvl_2_i_2
                                 tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_11 + tmp_lvl_val[tmp_lvl_q]
                                 input_lvl_2_q_2 += 1
+                            else
+                                phase_stop_16 = min(input_lvl_2_i_2, phase_stop_14)
+                                if input_lvl_2_i_2 == phase_stop_16
+                                    input_lvl_3_val_11 = input_lvl_2_val[input_lvl_2_q_2]
+                                    tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_16
+                                    tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_11 + tmp_lvl_val[tmp_lvl_q]
+                                    input_lvl_2_q_2 += 1
+                                end
+                                break
                             end
-                            x = phase_stop_14 + 1
                         end
                     end
-                    phase_start_15 = max(1, input_lvl_2_i1_3, 1 + input_lvl_2_i1_2)
-                    phase_stop_15 = min(input_lvl_2.shape, 1 + input_lvl_2_i1)
-                    if phase_stop_15 >= phase_start_15
-                        x = phase_start_15
-                        if input_lvl_idx[input_lvl_2_q] < phase_start_15 + -1
-                            input_lvl_2_q = Finch.scansearch(input_lvl_idx, phase_start_15 + -1, input_lvl_2_q, input_lvl_2_q_stop - 1)
+                    phase_start_16 = max(1, input_lvl_2_i1_3, 1 + input_lvl_2_i1_2)
+                    phase_stop_17 = min(input_lvl_2.shape, 1 + input_lvl_2_i1)
+                    if phase_stop_17 >= phase_start_16
+                        if input_lvl_idx[input_lvl_2_q] < phase_start_16 + -1
+                            input_lvl_2_q = Finch.scansearch(input_lvl_idx, phase_start_16 + -1, input_lvl_2_q, input_lvl_2_q_stop - 1)
                         end
-                        while x <= phase_stop_15
+                        while true
                             input_lvl_2_i = input_lvl_idx[input_lvl_2_q]
-                            phase_stop_16 = min(1 + input_lvl_2_i, phase_stop_15)
-                            if input_lvl_2_i == phase_stop_16 + -1
+                            phase_stop_18 = 1 + input_lvl_2_i
+                            if phase_stop_18 < phase_stop_17
                                 input_lvl_3_val_12 = input_lvl_2_val[input_lvl_2_q]
-                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_16
+                                tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_18
                                 tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_12 + tmp_lvl_val[tmp_lvl_q]
                                 input_lvl_2_q += 1
+                            else
+                                phase_stop_19 = min(1 + input_lvl_2_i, phase_stop_17)
+                                if input_lvl_2_i == phase_stop_19 + -1
+                                    input_lvl_3_val_12 = input_lvl_2_val[input_lvl_2_q]
+                                    tmp_lvl_q = (1 - 1) * input_lvl_2.shape + phase_stop_19
+                                    tmp_lvl_val[tmp_lvl_q] = input_lvl_3_val_12 + tmp_lvl_val[tmp_lvl_q]
+                                    input_lvl_2_q += 1
+                                end
+                                break
                             end
-                            x = phase_stop_16 + 1
                         end
                     end
-                    for x_43 = 1:input_lvl_2.shape
-                        output_lvl_2_q = (output_lvl_q - 1) * input_lvl_2.shape + x_43
-                        tmp_lvl_q_2 = (1 - 1) * input_lvl_2.shape + x_43
+                    for x_46 = 1:input_lvl_2.shape
+                        output_lvl_2_q = (output_lvl_q - 1) * input_lvl_2.shape + x_46
+                        tmp_lvl_q_2 = (1 - 1) * input_lvl_2.shape + x_46
                         tmp_lvl_2_val = tmp_lvl_val[tmp_lvl_q_2]
                         output_lvl_2_val[output_lvl_2_q] = tmp_lvl_2_val
                     end

--- a/test/reference64/short_circuit_sum.jl
+++ b/test/reference64/short_circuit_sum.jl
@@ -40,17 +40,25 @@ begin
                 if x_lvl_idx[x_lvl_q] < i
                     x_lvl_q = Finch.scansearch(x_lvl_idx, i, x_lvl_q, x_lvl_q_stop - 1)
                 end
-                while i <= phase_stop
+                while true
                     x_lvl_i = x_lvl_idx[x_lvl_q]
-                    phase_stop_3 = min(phase_stop, x_lvl_i)
-                    if x_lvl_i == phase_stop_3
+                    if x_lvl_i < phase_stop
                         x_lvl_2_val = x_lvl_val[x_lvl_q]
                         for i_9 = 1:phase_stop
                             c_val = x_lvl_2_val + c_val
                         end
                         x_lvl_q += 1
+                    else
+                        phase_stop_4 = min(phase_stop, x_lvl_i)
+                        if x_lvl_i == phase_stop_4
+                            x_lvl_2_val = x_lvl_val[x_lvl_q]
+                            for i_11 = 1:phase_stop
+                                c_val = x_lvl_2_val + c_val
+                            end
+                            x_lvl_q += 1
+                        end
+                        break
                     end
-                    i = phase_stop_3 + 1
                 end
                 break
             end
@@ -75,21 +83,26 @@ begin
         end
     end
     phase_start_5 = max(1, 1 + y_lvl_i1)
-    phase_stop_5 = min(y_lvl.shape, x_lvl_i1)
-    if phase_stop_5 >= phase_start_5
-        i = phase_start_5
+    phase_stop_6 = min(y_lvl.shape, x_lvl_i1)
+    if phase_stop_6 >= phase_start_5
         if x_lvl_idx[x_lvl_q] < phase_start_5
             x_lvl_q = Finch.scansearch(x_lvl_idx, phase_start_5, x_lvl_q, x_lvl_q_stop - 1)
         end
-        while i <= phase_stop_5
+        while true
             x_lvl_i = x_lvl_idx[x_lvl_q]
-            phase_stop_6 = min(x_lvl_i, phase_stop_5)
-            if x_lvl_i == phase_stop_6
+            if x_lvl_i < phase_stop_6
                 x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
                 c_val = x_lvl_2_val_2 + c_val
                 x_lvl_q += 1
+            else
+                phase_stop_8 = min(x_lvl_i, phase_stop_6)
+                if x_lvl_i == phase_stop_8
+                    x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
+                    c_val = x_lvl_2_val_2 + c_val
+                    x_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_6 + 1
         end
     end
     (c = (Scalar){0, Int64}(c_val), s = (ShortCircuitScalar){false, Bool, true}(s_val))

--- a/test/reference64/sieve_hl_cond.jl
+++ b/test/reference64/sieve_hl_cond.jl
@@ -15,19 +15,24 @@ begin
     phase_start_2 = max(1, 1 + (1 - 1))
     phase_stop_2 = min(A_lvl.shape, A_lvl_i1, 1)
     if phase_stop_2 >= phase_start_2
-        j = phase_start_2
         if A_lvl_idx[A_lvl_q] < phase_start_2
             A_lvl_q = Finch.scansearch(A_lvl_idx, phase_start_2, A_lvl_q, A_lvl_q_stop - 1)
         end
-        while j <= phase_stop_2
+        while true
             A_lvl_i = A_lvl_idx[A_lvl_q]
-            phase_stop_3 = min(phase_stop_2, A_lvl_i)
-            if A_lvl_i == phase_stop_3
+            if A_lvl_i < phase_stop_2
                 A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
                 B_val = A_lvl_2_val_2 + B_val
                 A_lvl_q += 1
+            else
+                phase_stop_4 = min(A_lvl_i, phase_stop_2)
+                if A_lvl_i == phase_stop_4
+                    A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
+                    B_val = B_val + A_lvl_2_val_2
+                    A_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_3 + 1
         end
     end
     (B = (Scalar){0.0, Float64}(B_val),)

--- a/test/reference64/sieve_hl_select.jl
+++ b/test/reference64/sieve_hl_select.jl
@@ -15,19 +15,24 @@ begin
     phase_start_2 = max(1, 1 + (3 - 1))
     phase_stop_2 = min(A_lvl.shape, A_lvl_i1, 3)
     if phase_stop_2 >= phase_start_2
-        j = phase_start_2
         if A_lvl_idx[A_lvl_q] < phase_start_2
             A_lvl_q = Finch.scansearch(A_lvl_idx, phase_start_2, A_lvl_q, A_lvl_q_stop - 1)
         end
-        while j <= phase_stop_2
+        while true
             A_lvl_i = A_lvl_idx[A_lvl_q]
-            phase_stop_3 = min(phase_stop_2, A_lvl_i)
-            if A_lvl_i == phase_stop_3
+            if A_lvl_i < phase_stop_2
                 A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
                 B_val = A_lvl_2_val_2 + B_val
                 A_lvl_q += 1
+            else
+                phase_stop_4 = min(A_lvl_i, phase_stop_2)
+                if A_lvl_i == phase_stop_4
+                    A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
+                    B_val = B_val + A_lvl_2_val_2
+                    A_lvl_q += 1
+                end
+                break
             end
-            j = phase_stop_3 + 1
         end
     end
     (B = (Scalar){0.0, Float64}(B_val),)

--- a/test/reference64/sparse_conv.jl
+++ b/test/reference64/sparse_conv.jl
@@ -24,14 +24,12 @@ begin
     end
     phase_stop = min(A_lvl_i1_2, A_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if A_lvl_idx[A_lvl_q_2] < 1
             A_lvl_q_2 = Finch.scansearch(A_lvl_idx, 1, A_lvl_q_2, A_lvl_q_stop_2 - 1)
         end
-        while i <= phase_stop
+        while true
             A_lvl_i_2 = A_lvl_idx[A_lvl_q_2]
-            phase_stop_2 = min(phase_stop, A_lvl_i_2)
-            if A_lvl_i_2 == phase_stop_2
+            if A_lvl_i_2 < phase_stop
                 A_lvl_2_val = A_lvl_val[A_lvl_q_2]
                 if C_lvl_qos > C_lvl_qos_stop
                     C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -40,10 +38,10 @@ begin
                     Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
                 end
                 C_lvldirty = false
-                v_3 = -phase_stop_2
-                phase_start_4 = max(1, -v_3 + -2)
+                v_3 = -A_lvl_i_2
+                phase_start_3 = max(1, -v_3 + -2)
                 phase_stop_4 = min(F_lvl.shape, A_lvl.shape + -v_3 + -3)
-                if phase_stop_4 >= phase_start_4
+                if phase_stop_4 >= phase_start_3
                     A_lvl_q = A_lvl_ptr[1]
                     A_lvl_q_stop = A_lvl_ptr[1 + 1]
                     if A_lvl_q < A_lvl_q_stop
@@ -52,33 +50,100 @@ begin
                         A_lvl_i1 = 0
                     end
                     phase_stop_5 = min(phase_stop_4, -v_3 + -3 + A_lvl_i1)
-                    if phase_stop_5 >= phase_start_4
-                        j = phase_start_4
-                        if A_lvl_idx[A_lvl_q] < (phase_start_4 + v_3) + 3
-                            A_lvl_q = Finch.scansearch(A_lvl_idx, (phase_start_4 + v_3) + 3, A_lvl_q, A_lvl_q_stop - 1)
+                    if phase_stop_5 >= phase_start_3
+                        if A_lvl_idx[A_lvl_q] < (phase_start_3 + v_3) + 3
+                            A_lvl_q = Finch.scansearch(A_lvl_idx, (phase_start_3 + v_3) + 3, A_lvl_q, A_lvl_q_stop - 1)
                         end
-                        while j <= phase_stop_5
+                        while true
                             A_lvl_i = A_lvl_idx[A_lvl_q]
-                            phase_stop_6 = min(phase_stop_5, -v_3 + -3 + A_lvl_i)
-                            if A_lvl_i == (phase_stop_6 + v_3) + 3
+                            phase_stop_6 = -v_3 + -3 + A_lvl_i
+                            if phase_stop_6 < phase_stop_5
                                 A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
                                 F_lvl_q = (1 - 1) * F_lvl.shape + phase_stop_6
                                 F_lvl_2_val = F_lvl_val[F_lvl_q]
                                 C_lvldirty = true
                                 C_lvl_val[C_lvl_qos] = C_lvl_val[C_lvl_qos] + (A_lvl_2_val != 0) * F_lvl_2_val * coalesce(A_lvl_2_val_2, 0)
                                 A_lvl_q += 1
+                            else
+                                phase_stop_7 = min(phase_stop_5, -v_3 + -3 + A_lvl_i)
+                                if A_lvl_i == (phase_stop_7 + v_3) + 3
+                                    A_lvl_2_val_2 = A_lvl_val[A_lvl_q]
+                                    F_lvl_q = (1 - 1) * F_lvl.shape + phase_stop_7
+                                    F_lvl_2_val_2 = F_lvl_val[F_lvl_q]
+                                    C_lvldirty = true
+                                    C_lvl_val[C_lvl_qos] = C_lvl_val[C_lvl_qos] + (A_lvl_2_val != 0) * F_lvl_2_val_2 * coalesce(A_lvl_2_val_2, 0)
+                                    A_lvl_q += 1
+                                end
+                                break
                             end
-                            j = phase_stop_6 + 1
                         end
                     end
                 end
                 if C_lvldirty
-                    C_lvl_idx[C_lvl_qos] = phase_stop_2
+                    C_lvl_idx[C_lvl_qos] = A_lvl_i_2
                     C_lvl_qos += 1
                 end
                 A_lvl_q_2 += 1
+            else
+                phase_stop_10 = min(A_lvl_i_2, phase_stop)
+                if A_lvl_i_2 == phase_stop_10
+                    A_lvl_2_val = A_lvl_val[A_lvl_q_2]
+                    if C_lvl_qos > C_lvl_qos_stop
+                        C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                        Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                        Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                    end
+                    C_lvldirty = false
+                    v_5 = -phase_stop_10
+                    phase_start_11 = max(1, -2 + -v_5)
+                    phase_stop_12 = min(F_lvl.shape, A_lvl.shape + -3 + -v_5)
+                    if phase_stop_12 >= phase_start_11
+                        A_lvl_q = A_lvl_ptr[1]
+                        A_lvl_q_stop = A_lvl_ptr[1 + 1]
+                        if A_lvl_q < A_lvl_q_stop
+                            A_lvl_i1 = A_lvl_idx[A_lvl_q_stop - 1]
+                        else
+                            A_lvl_i1 = 0
+                        end
+                        phase_stop_13 = min(phase_stop_12, -3 + A_lvl_i1 + -v_5)
+                        if phase_stop_13 >= phase_start_11
+                            if A_lvl_idx[A_lvl_q] < (phase_start_11 + v_5) + 3
+                                A_lvl_q = Finch.scansearch(A_lvl_idx, (phase_start_11 + v_5) + 3, A_lvl_q, A_lvl_q_stop - 1)
+                            end
+                            while true
+                                A_lvl_i = A_lvl_idx[A_lvl_q]
+                                phase_stop_14 = -3 + A_lvl_i + -v_5
+                                if phase_stop_14 < phase_stop_13
+                                    A_lvl_2_val_3 = A_lvl_val[A_lvl_q]
+                                    F_lvl_q = (1 - 1) * F_lvl.shape + phase_stop_14
+                                    F_lvl_2_val_3 = F_lvl_val[F_lvl_q]
+                                    C_lvldirty = true
+                                    C_lvl_val[C_lvl_qos] = C_lvl_val[C_lvl_qos] + (A_lvl_2_val != 0) * F_lvl_2_val_3 * coalesce(A_lvl_2_val_3, 0)
+                                    A_lvl_q += 1
+                                else
+                                    phase_stop_15 = min(phase_stop_13, -3 + A_lvl_i + -v_5)
+                                    if A_lvl_i == (phase_stop_15 + v_5) + 3
+                                        A_lvl_2_val_3 = A_lvl_val[A_lvl_q]
+                                        F_lvl_q = (1 - 1) * F_lvl.shape + phase_stop_15
+                                        F_lvl_2_val_4 = F_lvl_val[F_lvl_q]
+                                        C_lvldirty = true
+                                        C_lvl_val[C_lvl_qos] = C_lvl_val[C_lvl_qos] + (A_lvl_2_val != 0) * F_lvl_2_val_4 * coalesce(A_lvl_2_val_3, 0)
+                                        A_lvl_q += 1
+                                    end
+                                    break
+                                end
+                            end
+                        end
+                    end
+                    if C_lvldirty
+                        C_lvl_idx[C_lvl_qos] = phase_stop_10
+                        C_lvl_qos += 1
+                    end
+                    A_lvl_q_2 += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     C_lvl_ptr[1 + 1] = (C_lvl_qos - 0) - 1

--- a/test/reference64/sparse_window.jl
+++ b/test/reference64/sparse_window.jl
@@ -22,14 +22,13 @@ begin
     end
     phase_stop = min(3, A_lvl_i1 + -1)
     if phase_stop >= 1
-        i = 1
         if A_lvl_idx[A_lvl_q] < 1 + 1
             A_lvl_q = Finch.scansearch(A_lvl_idx, 1 + 1, A_lvl_q, A_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             A_lvl_i = A_lvl_idx[A_lvl_q]
-            phase_stop_2 = min(phase_stop, -1 + A_lvl_i)
-            if A_lvl_i == phase_stop_2 + 1
+            phase_stop_2 = -1 + A_lvl_i
+            if phase_stop_2 < phase_stop
                 A_lvl_2_val = A_lvl_val[A_lvl_q]
                 if C_lvl_qos > C_lvl_qos_stop
                     C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
@@ -41,8 +40,23 @@ begin
                 C_lvl_idx[C_lvl_qos] = phase_stop_2
                 C_lvl_qos += 1
                 A_lvl_q += 1
+            else
+                phase_stop_3 = min(phase_stop, -1 + A_lvl_i)
+                if A_lvl_i == phase_stop_3 + 1
+                    A_lvl_2_val = A_lvl_val[A_lvl_q]
+                    if C_lvl_qos > C_lvl_qos_stop
+                        C_lvl_qos_stop = max(C_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(C_lvl_idx, C_lvl_qos_stop)
+                        Finch.resize_if_smaller!(C_lvl_val, C_lvl_qos_stop)
+                        Finch.fill_range!(C_lvl_val, 0.0, C_lvl_qos, C_lvl_qos_stop)
+                    end
+                    C_lvl_val[C_lvl_qos] = A_lvl_2_val
+                    C_lvl_idx[C_lvl_qos] = phase_stop_3
+                    C_lvl_qos += 1
+                    A_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     C_lvl_ptr[1 + 1] = (C_lvl_qos - 0) - 1

--- a/test/reference64/specialvals_minimum_inf.jl
+++ b/test/reference64/specialvals_minimum_inf.jl
@@ -14,19 +14,24 @@ begin
     end
     phase_stop = min(yf_lvl_i1, yf_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if yf_lvl_idx[yf_lvl_q] < 1
             yf_lvl_q = Finch.scansearch(yf_lvl_idx, 1, yf_lvl_q, yf_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             yf_lvl_i = yf_lvl_idx[yf_lvl_q]
-            phase_stop_2 = min(phase_stop, yf_lvl_i)
-            if yf_lvl_i == phase_stop_2
+            if yf_lvl_i < phase_stop
                 yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
                 x_val = min(yf_lvl_2_val, x_val)
                 yf_lvl_q += 1
+            else
+                phase_stop_3 = min(yf_lvl_i, phase_stop)
+                if yf_lvl_i == phase_stop_3
+                    yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
+                    x_val = min(x_val, yf_lvl_2_val)
+                    yf_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     (x = (Scalar){Inf, Float64}(x_val),)

--- a/test/reference64/specialvals_minimum_missing.jl
+++ b/test/reference64/specialvals_minimum_missing.jl
@@ -18,31 +18,43 @@ begin
         if yf_lvl_idx[yf_lvl_q] < 1
             yf_lvl_q = Finch.scansearch(yf_lvl_idx, 1, yf_lvl_q, yf_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             yf_lvl_i = yf_lvl_idx[yf_lvl_q]
-            phase_stop_2 = min(phase_stop, yf_lvl_i)
-            if yf_lvl_i == phase_stop_2
-                cond = 0 < -i + phase_stop_2
+            if yf_lvl_i < phase_stop
+                cond = 0 < -i + yf_lvl_i
                 if cond
                     x_val = missing
                 end
                 yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
                 x_val = min(x_val, yf_lvl_2_val)
                 yf_lvl_q += 1
+                i = yf_lvl_i + 1
             else
-                cond_3 = 0 < 1 + -i + phase_stop_2
-                if cond_3
-                    x_val = missing
+                phase_stop_3 = min(yf_lvl_i, phase_stop)
+                if yf_lvl_i == phase_stop_3
+                    cond_3 = 0 < -i + phase_stop_3
+                    if cond_3
+                        x_val = missing
+                    end
+                    yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
+                    x_val = min(x_val, yf_lvl_2_val)
+                    yf_lvl_q += 1
+                else
+                    cond_5 = 0 < 1 + -i + phase_stop_3
+                    if cond_5
+                        x_val = missing
+                    end
                 end
+                i = phase_stop_3 + 1
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     phase_start_3 = max(1, 1 + yf_lvl_i1)
-    phase_stop_3 = yf_lvl.shape
-    if phase_stop_3 >= phase_start_3
-        cond_4 = 0 < 1 + -phase_start_3 + phase_stop_3
-        if cond_4
+    phase_stop_4 = yf_lvl.shape
+    if phase_stop_4 >= phase_start_3
+        cond_6 = 0 < 1 + -phase_start_3 + phase_stop_4
+        if cond_6
             x_val = missing
         end
     end

--- a/test/reference64/specialvals_minimum_nan.jl
+++ b/test/reference64/specialvals_minimum_nan.jl
@@ -18,31 +18,43 @@ begin
         if yf_lvl_idx[yf_lvl_q] < 1
             yf_lvl_q = Finch.scansearch(yf_lvl_idx, 1, yf_lvl_q, yf_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             yf_lvl_i = yf_lvl_idx[yf_lvl_q]
-            phase_stop_2 = min(phase_stop, yf_lvl_i)
-            if yf_lvl_i == phase_stop_2
-                cond = 0 < -i + phase_stop_2
+            if yf_lvl_i < phase_stop
+                cond = 0 < -i + yf_lvl_i
                 if cond
                     x_val = min(NaN, x_val)
                 end
                 yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
                 x_val = min(x_val, yf_lvl_2_val)
                 yf_lvl_q += 1
+                i = yf_lvl_i + 1
             else
-                cond_3 = 0 < 1 + -i + phase_stop_2
-                if cond_3
-                    x_val = min(NaN, x_val)
+                phase_stop_3 = min(yf_lvl_i, phase_stop)
+                if yf_lvl_i == phase_stop_3
+                    cond_3 = 0 < -i + phase_stop_3
+                    if cond_3
+                        x_val = min(NaN, x_val)
+                    end
+                    yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
+                    x_val = min(x_val, yf_lvl_2_val)
+                    yf_lvl_q += 1
+                else
+                    cond_5 = 0 < 1 + -i + phase_stop_3
+                    if cond_5
+                        x_val = min(NaN, x_val)
+                    end
                 end
+                i = phase_stop_3 + 1
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     phase_start_3 = max(1, 1 + yf_lvl_i1)
-    phase_stop_3 = yf_lvl.shape
-    if phase_stop_3 >= phase_start_3
-        cond_4 = 0 < 1 + -phase_start_3 + phase_stop_3
-        if cond_4
+    phase_stop_4 = yf_lvl.shape
+    if phase_stop_4 >= phase_start_3
+        cond_6 = 0 < 1 + -phase_start_3 + phase_stop_4
+        if cond_6
             x_val = min(NaN, x_val)
         end
     end

--- a/test/reference64/specialvals_minimum_nothing.jl
+++ b/test/reference64/specialvals_minimum_nothing.jl
@@ -14,19 +14,24 @@ begin
     end
     phase_stop = min(yf_lvl_i1, yf_lvl.shape)
     if phase_stop >= 1
-        i = 1
         if yf_lvl_idx[yf_lvl_q] < 1
             yf_lvl_q = Finch.scansearch(yf_lvl_idx, 1, yf_lvl_q, yf_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             yf_lvl_i = yf_lvl_idx[yf_lvl_q]
-            phase_stop_2 = min(phase_stop, yf_lvl_i)
-            if yf_lvl_i == phase_stop_2
+            if yf_lvl_i < phase_stop
                 yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
                 x_val = min(something(yf_lvl_2_val, Inf), x_val)
                 yf_lvl_q += 1
+            else
+                phase_stop_3 = min(yf_lvl_i, phase_stop)
+                if yf_lvl_i == phase_stop_3
+                    yf_lvl_2_val = yf_lvl_val[yf_lvl_q]
+                    x_val = min(x_val, something(yf_lvl_2_val, Inf))
+                    yf_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     (x = (Scalar){Inf, Float64}(x_val),)

--- a/test/reference64/triangle.jl
+++ b/test/reference64/triangle.jl
@@ -19,16 +19,14 @@ begin
         end
         phase_stop = min(A_lvl.shape, A_lvl_2_i1)
         if phase_stop >= 1
-            j = 1
             if A_lvl_idx[A_lvl_2_q] < 1
                 A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
             end
-            while j <= phase_stop
+            while true
                 A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                if A_lvl_2_i == phase_stop_2
+                if A_lvl_2_i < phase_stop
                     A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
-                    A_lvl_q_3 = (1 - 1) * A_lvl.shape + phase_stop_2
+                    A_lvl_q_3 = (1 - 1) * A_lvl.shape + A_lvl_2_i
                     A_lvl_2_q_2 = A_lvl_ptr[A_lvl_q_2]
                     A_lvl_2_q_stop_2 = A_lvl_ptr[A_lvl_q_2 + 1]
                     if A_lvl_2_q_2 < A_lvl_2_q_stop_2
@@ -71,8 +69,56 @@ begin
                         end
                     end
                     A_lvl_2_q += 1
+                else
+                    phase_stop_8 = min(A_lvl_2_i, phase_stop)
+                    if A_lvl_2_i == phase_stop_8
+                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                        A_lvl_q_3 = (1 - 1) * A_lvl.shape + phase_stop_8
+                        A_lvl_2_q_2 = A_lvl_ptr[A_lvl_q_2]
+                        A_lvl_2_q_stop_2 = A_lvl_ptr[A_lvl_q_2 + 1]
+                        if A_lvl_2_q_2 < A_lvl_2_q_stop_2
+                            A_lvl_2_i1_2 = A_lvl_idx[A_lvl_2_q_stop_2 - 1]
+                        else
+                            A_lvl_2_i1_2 = 0
+                        end
+                        A_lvl_2_q_4 = A_lvl_ptr[A_lvl_q_3]
+                        A_lvl_2_q_stop_4 = A_lvl_ptr[A_lvl_q_3 + 1]
+                        if A_lvl_2_q_4 < A_lvl_2_q_stop_4
+                            A_lvl_2_i1_4 = A_lvl_idx[A_lvl_2_q_stop_4 - 1]
+                        else
+                            A_lvl_2_i1_4 = 0
+                        end
+                        phase_stop_9 = min(A_lvl_2.shape, A_lvl_2_i1_2, A_lvl_2_i1_4)
+                        if phase_stop_9 >= 1
+                            k = 1
+                            if A_lvl_idx[A_lvl_2_q_2] < 1
+                                A_lvl_2_q_2 = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q_2, A_lvl_2_q_stop_2 - 1)
+                            end
+                            if A_lvl_idx[A_lvl_2_q_4] < 1
+                                A_lvl_2_q_4 = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q_4, A_lvl_2_q_stop_4 - 1)
+                            end
+                            while k <= phase_stop_9
+                                A_lvl_2_i_2 = A_lvl_idx[A_lvl_2_q_2]
+                                A_lvl_2_i_4 = A_lvl_idx[A_lvl_2_q_4]
+                                phase_stop_10 = min(A_lvl_2_i_2, A_lvl_2_i_4, phase_stop_9)
+                                if A_lvl_2_i_2 == phase_stop_10 && A_lvl_2_i_4 == phase_stop_10
+                                    A_lvl_3_val_6 = A_lvl_2_val[A_lvl_2_q_2]
+                                    A_lvl_3_val_7 = A_lvl_2_val[A_lvl_2_q_4]
+                                    B_val = B_val + A_lvl_3_val * A_lvl_3_val_6 * A_lvl_3_val_7
+                                    A_lvl_2_q_2 += 1
+                                    A_lvl_2_q_4 += 1
+                                elseif A_lvl_2_i_4 == phase_stop_10
+                                    A_lvl_2_q_4 += 1
+                                elseif A_lvl_2_i_2 == phase_stop_10
+                                    A_lvl_2_q_2 += 1
+                                end
+                                k = phase_stop_10 + 1
+                            end
+                        end
+                        A_lvl_2_q += 1
+                    end
+                    break
                 end
-                j = phase_stop_2 + 1
             end
         end
     end

--- a/test/reference64/typical_inplace_sparse_add.txt
+++ b/test/reference64/typical_inplace_sparse_add.txt
@@ -33,20 +33,26 @@ quote
     end
     phase_stop = min(A_lvl.shape, A_lvl_i1)
     if phase_stop >= 1
-        i = 1
         if A_lvl_idx[A_lvl_q] < 1
             A_lvl_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_q, A_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             A_lvl_i = A_lvl_idx[A_lvl_q]
-            phase_stop_2 = min(phase_stop, A_lvl_i)
-            if A_lvl_i == phase_stop_2
+            if A_lvl_i < phase_stop
                 A_lvl_2_val = A_lvl_val[A_lvl_q]
-                B_lvl_q = (1 - 1) * B_lvl.shape + phase_stop_2
+                B_lvl_q = (1 - 1) * B_lvl.shape + A_lvl_i
                 B_lvl_val[B_lvl_q] = A_lvl_2_val + B_lvl_val[B_lvl_q]
                 A_lvl_q += 1
+            else
+                phase_stop_3 = min(A_lvl_i, phase_stop)
+                if A_lvl_i == phase_stop_3
+                    A_lvl_2_val = A_lvl_val[A_lvl_q]
+                    B_lvl_q = (1 - 1) * B_lvl.shape + phase_stop_3
+                    B_lvl_val[B_lvl_q] = A_lvl_2_val + B_lvl_val[B_lvl_q]
+                    A_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     qos = 1 * B_lvl.shape

--- a/test/reference64/typical_merge_gallop.txt
+++ b/test/reference64/typical_merge_gallop.txt
@@ -69,10 +69,9 @@ quote
                 if y_lvl_idx[y_lvl_q] < i
                     y_lvl_q = Finch.scansearch(y_lvl_idx, i, y_lvl_q, y_lvl_q_stop - 1)
                 end
-                while i <= phase_stop_2 - 1
+                while true
                     y_lvl_i2 = y_lvl_idx[y_lvl_q]
-                    phase_stop_3 = min(y_lvl_i2, -1 + phase_stop_2)
-                    if y_lvl_i2 == phase_stop_3
+                    if y_lvl_i2 < phase_stop_2 - 1
                         y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -81,20 +80,34 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_3
+                        z_lvl_idx[z_lvl_qos] = y_lvl_i2
                         z_lvl_qos += 1
                         y_lvl_q += 1
+                    else
+                        phase_stop_4 = min(y_lvl_i2, -1 + phase_stop_2)
+                        if y_lvl_i2 == phase_stop_4
+                            y_lvl_2_val = y_lvl_val[y_lvl_q]
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = y_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = phase_stop_4
+                            z_lvl_qos += 1
+                            y_lvl_q += 1
+                        end
+                        break
                     end
-                    i = phase_stop_3 + 1
                 end
                 x_lvl_2_val = x_lvl_val[x_lvl_q]
                 if y_lvl_idx[y_lvl_q] < phase_stop_2
                     y_lvl_q = Finch.scansearch(y_lvl_idx, phase_stop_2, y_lvl_q, y_lvl_q_stop - 1)
                 end
                 y_lvl_i2 = y_lvl_idx[y_lvl_q]
-                phase_stop_4 = min(y_lvl_i2, phase_stop_2)
-                if y_lvl_i2 == phase_stop_4
-                    for i_11 = phase_stop_2:phase_stop_4 - 1
+                if y_lvl_i2 < phase_stop_2
+                    for i_12 = phase_stop_2:y_lvl_i2 - 1
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
                             Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
@@ -102,7 +115,7 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = i_11
+                        z_lvl_idx[z_lvl_qos] = i_12
                         z_lvl_qos += 1
                     end
                     y_lvl_2_val = y_lvl_val[y_lvl_q]
@@ -113,31 +126,58 @@ quote
                         Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                     end
                     z_lvl_val[z_lvl_qos] = x_lvl_2_val + y_lvl_2_val
-                    z_lvl_idx[z_lvl_qos] = phase_stop_4
+                    z_lvl_idx[z_lvl_qos] = y_lvl_i2
                     z_lvl_qos += 1
                     y_lvl_q += 1
                 else
-                    for i_13 = phase_stop_2:phase_stop_4
+                    phase_stop_6 = min(y_lvl_i2, phase_stop_2)
+                    if y_lvl_i2 == phase_stop_6
+                        for i_14 = phase_stop_2:phase_stop_6 - 1
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = i_14
+                            z_lvl_qos += 1
+                        end
+                        y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
                             Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
                             Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
-                        z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = i_13
+                        z_lvl_val[z_lvl_qos] = x_lvl_2_val + y_lvl_2_val
+                        z_lvl_idx[z_lvl_qos] = phase_stop_6
                         z_lvl_qos += 1
+                        y_lvl_q += 1
+                    else
+                        for i_16 = phase_stop_2:phase_stop_6
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = i_16
+                            z_lvl_qos += 1
+                        end
                     end
+                    x_lvl_q += 1
+                    break
                 end
                 x_lvl_q += 1
             elseif y_lvl_i2 == phase_stop_2
                 if x_lvl_idx[x_lvl_q] < i
                     x_lvl_q = Finch.scansearch(x_lvl_idx, i, x_lvl_q, x_lvl_q_stop - 1)
                 end
-                while i <= phase_stop_2 - 1
+                while true
                     x_lvl_i2 = x_lvl_idx[x_lvl_q]
-                    phase_stop_5 = min(x_lvl_i2, -1 + phase_stop_2)
-                    if x_lvl_i2 == phase_stop_5
+                    if x_lvl_i2 < phase_stop_2 - 1
                         x_lvl_2_val = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -146,20 +186,34 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_5
+                        z_lvl_idx[z_lvl_qos] = x_lvl_i2
                         z_lvl_qos += 1
                         x_lvl_q += 1
+                    else
+                        phase_stop_8 = min(x_lvl_i2, -1 + phase_stop_2)
+                        if x_lvl_i2 == phase_stop_8
+                            x_lvl_2_val = x_lvl_val[x_lvl_q]
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = phase_stop_8
+                            z_lvl_qos += 1
+                            x_lvl_q += 1
+                        end
+                        break
                     end
-                    i = phase_stop_5 + 1
                 end
                 y_lvl_2_val = y_lvl_val[y_lvl_q]
                 if x_lvl_idx[x_lvl_q] < phase_stop_2
                     x_lvl_q = Finch.scansearch(x_lvl_idx, phase_stop_2, x_lvl_q, x_lvl_q_stop - 1)
                 end
                 x_lvl_i2 = x_lvl_idx[x_lvl_q]
-                phase_stop_6 = min(x_lvl_i2, phase_stop_2)
-                if x_lvl_i2 == phase_stop_6
-                    for i_17 = phase_stop_2:phase_stop_6 - 1
+                if x_lvl_i2 < phase_stop_2
+                    for i_21 = phase_stop_2:x_lvl_i2 - 1
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
                             Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
@@ -167,7 +221,7 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = i_17
+                        z_lvl_idx[z_lvl_qos] = i_21
                         z_lvl_qos += 1
                     end
                     x_lvl_2_val = x_lvl_val[x_lvl_q]
@@ -178,21 +232,49 @@ quote
                         Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                     end
                     z_lvl_val[z_lvl_qos] = y_lvl_2_val + x_lvl_2_val
-                    z_lvl_idx[z_lvl_qos] = phase_stop_6
+                    z_lvl_idx[z_lvl_qos] = x_lvl_i2
                     z_lvl_qos += 1
                     x_lvl_q += 1
                 else
-                    for i_19 = phase_stop_2:phase_stop_6
+                    phase_stop_10 = min(x_lvl_i2, phase_stop_2)
+                    if x_lvl_i2 == phase_stop_10
+                        for i_23 = phase_stop_2:phase_stop_10 - 1
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = y_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = i_23
+                            z_lvl_qos += 1
+                        end
+                        x_lvl_2_val = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
                             Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
                             Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
-                        z_lvl_val[z_lvl_qos] = y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = i_19
+                        z_lvl_val[z_lvl_qos] = y_lvl_2_val + x_lvl_2_val
+                        z_lvl_idx[z_lvl_qos] = phase_stop_10
                         z_lvl_qos += 1
+                        x_lvl_q += 1
+                    else
+                        for i_25 = phase_stop_2:phase_stop_10
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = y_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = i_25
+                            z_lvl_qos += 1
+                        end
                     end
+                    y_lvl_q += 1
+                    break
                 end
                 y_lvl_q += 1
             else
@@ -205,8 +287,8 @@ quote
                 while i <= phase_stop_2
                     y_lvl_i2 = y_lvl_idx[y_lvl_q]
                     x_lvl_i2 = x_lvl_idx[x_lvl_q]
-                    phase_stop_7 = min(y_lvl_i2, x_lvl_i2, phase_stop_2)
-                    if y_lvl_i2 == phase_stop_7 && x_lvl_i2 == phase_stop_7
+                    phase_stop_11 = min(y_lvl_i2, x_lvl_i2, phase_stop_2)
+                    if y_lvl_i2 == phase_stop_11 && x_lvl_i2 == phase_stop_11
                         y_lvl_2_val = y_lvl_val[y_lvl_q]
                         x_lvl_2_val = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
@@ -216,11 +298,11 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val + y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_7
+                        z_lvl_idx[z_lvl_qos] = phase_stop_11
                         z_lvl_qos += 1
                         y_lvl_q += 1
                         x_lvl_q += 1
-                    elseif x_lvl_i2 == phase_stop_7
+                    elseif x_lvl_i2 == phase_stop_11
                         x_lvl_2_val = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -229,10 +311,10 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_7
+                        z_lvl_idx[z_lvl_qos] = phase_stop_11
                         z_lvl_qos += 1
                         x_lvl_q += 1
-                    elseif y_lvl_i2 == phase_stop_7
+                    elseif y_lvl_i2 == phase_stop_11
                         y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -241,27 +323,27 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_7
+                        z_lvl_idx[z_lvl_qos] = phase_stop_11
                         z_lvl_qos += 1
                         y_lvl_q += 1
                     end
-                    i = phase_stop_7 + 1
+                    i = phase_stop_11 + 1
                 end
             end
             i = phase_stop_2 + 1
         end
     end
     phase_start_8 = max(1, 1 + y_lvl_i1)
-    phase_stop_8 = min(y_lvl.shape, x_lvl_i1)
-    if phase_stop_8 >= phase_start_8
+    phase_stop_12 = min(y_lvl.shape, x_lvl_i1)
+    if phase_stop_12 >= phase_start_8
         i = phase_start_8
-        while i <= phase_stop_8
+        while i <= phase_stop_12
             if x_lvl_idx[x_lvl_q] < i
                 x_lvl_q = Finch.scansearch(x_lvl_idx, i, x_lvl_q, x_lvl_q_stop - 1)
             end
             x_lvl_i2 = x_lvl_idx[x_lvl_q]
-            phase_stop_9 = min(x_lvl_i2, phase_stop_8)
-            if x_lvl_i2 == phase_stop_9
+            phase_stop_13 = min(x_lvl_i2, phase_stop_12)
+            if x_lvl_i2 == phase_stop_13
                 x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
                 if z_lvl_qos > z_lvl_qos_stop
                     z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -270,17 +352,16 @@ quote
                     Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                 end
                 z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
-                z_lvl_idx[z_lvl_qos] = phase_stop_9
+                z_lvl_idx[z_lvl_qos] = phase_stop_13
                 z_lvl_qos += 1
                 x_lvl_q += 1
             else
                 if x_lvl_idx[x_lvl_q] < i
                     x_lvl_q = Finch.scansearch(x_lvl_idx, i, x_lvl_q, x_lvl_q_stop - 1)
                 end
-                while i <= phase_stop_9
+                while true
                     x_lvl_i2 = x_lvl_idx[x_lvl_q]
-                    phase_stop_10 = min(x_lvl_i2, phase_stop_9)
-                    if x_lvl_i2 == phase_stop_10
+                    if x_lvl_i2 < phase_stop_13
                         x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -289,27 +370,42 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
-                        z_lvl_idx[z_lvl_qos] = phase_stop_10
+                        z_lvl_idx[z_lvl_qos] = x_lvl_i2
                         z_lvl_qos += 1
                         x_lvl_q += 1
+                    else
+                        phase_stop_15 = min(x_lvl_i2, phase_stop_13)
+                        if x_lvl_i2 == phase_stop_15
+                            x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
+                            z_lvl_idx[z_lvl_qos] = phase_stop_15
+                            z_lvl_qos += 1
+                            x_lvl_q += 1
+                        end
+                        break
                     end
-                    i = phase_stop_10 + 1
                 end
             end
-            i = phase_stop_9 + 1
+            i = phase_stop_13 + 1
         end
     end
     phase_start_11 = max(1, 1 + x_lvl_i1)
-    phase_stop_11 = min(y_lvl.shape, y_lvl_i1)
-    if phase_stop_11 >= phase_start_11
+    phase_stop_16 = min(y_lvl.shape, y_lvl_i1)
+    if phase_stop_16 >= phase_start_11
         i = phase_start_11
-        while i <= phase_stop_11
+        while i <= phase_stop_16
             if y_lvl_idx[y_lvl_q] < i
                 y_lvl_q = Finch.scansearch(y_lvl_idx, i, y_lvl_q, y_lvl_q_stop - 1)
             end
             y_lvl_i2 = y_lvl_idx[y_lvl_q]
-            phase_stop_12 = min(y_lvl_i2, phase_stop_11)
-            if y_lvl_i2 == phase_stop_12
+            phase_stop_17 = min(y_lvl_i2, phase_stop_16)
+            if y_lvl_i2 == phase_stop_17
                 y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
                 if z_lvl_qos > z_lvl_qos_stop
                     z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -318,17 +414,16 @@ quote
                     Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                 end
                 z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
-                z_lvl_idx[z_lvl_qos] = phase_stop_12
+                z_lvl_idx[z_lvl_qos] = phase_stop_17
                 z_lvl_qos += 1
                 y_lvl_q += 1
             else
                 if y_lvl_idx[y_lvl_q] < i
                     y_lvl_q = Finch.scansearch(y_lvl_idx, i, y_lvl_q, y_lvl_q_stop - 1)
                 end
-                while i <= phase_stop_12
+                while true
                     y_lvl_i2 = y_lvl_idx[y_lvl_q]
-                    phase_stop_13 = min(y_lvl_i2, phase_stop_12)
-                    if y_lvl_i2 == phase_stop_13
+                    if y_lvl_i2 < phase_stop_17
                         y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -337,14 +432,29 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
-                        z_lvl_idx[z_lvl_qos] = phase_stop_13
+                        z_lvl_idx[z_lvl_qos] = y_lvl_i2
                         z_lvl_qos += 1
                         y_lvl_q += 1
+                    else
+                        phase_stop_19 = min(y_lvl_i2, phase_stop_17)
+                        if y_lvl_i2 == phase_stop_19
+                            y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
+                            z_lvl_idx[z_lvl_qos] = phase_stop_19
+                            z_lvl_qos += 1
+                            y_lvl_q += 1
+                        end
+                        break
                     end
-                    i = phase_stop_13 + 1
                 end
             end
-            i = phase_stop_12 + 1
+            i = phase_stop_17 + 1
         end
     end
     z_lvl_ptr[1 + 1] = (z_lvl_qos - 0) - 1
@@ -363,5 +473,5 @@ julia> @finch begin
             z[i] = x[gallop(i)] + y[gallop(i)]
         end
     end
-(z = Fiber(SparseList{Int64}(Element{0.0, Float64, Int64}([2.0, 1.0, 3.0, 5.0, 5.0, 1.0, 6.0]), 10, [1, 8], [1, 2, 3, 5, 7, 8, 9])),)
+(z = Fiber(SparseList{Int64}(Element{0.0, Float64, Int64}([2.0, 1.0, 6.0]), 10, [1, 4], [1, 2, 9])),)
 

--- a/test/reference64/typical_merge_leadfollow.txt
+++ b/test/reference64/typical_merge_leadfollow.txt
@@ -51,10 +51,9 @@ quote
                 if y_lvl_idx[y_lvl_q] < i
                     y_lvl_q = Finch.scansearch(y_lvl_idx, i, y_lvl_q, y_lvl_q_stop - 1)
                 end
-                while i <= phase_stop_2 - 1
+                while true
                     y_lvl_i = y_lvl_idx[y_lvl_q]
-                    phase_stop_3 = min(y_lvl_i, -1 + phase_stop_2)
-                    if y_lvl_i == phase_stop_3
+                    if y_lvl_i < phase_stop_2 - 1
                         y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -63,20 +62,32 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_3
+                        z_lvl_idx[z_lvl_qos] = y_lvl_i
                         z_lvl_qos += 1
                         y_lvl_q += 1
+                    else
+                        phase_stop_4 = min(y_lvl_i, -1 + phase_stop_2)
+                        y_lvl_2_val = y_lvl_val[y_lvl_q]
+                        if z_lvl_qos > z_lvl_qos_stop
+                            z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                            Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                            Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                        end
+                        z_lvl_val[z_lvl_qos] = y_lvl_2_val
+                        z_lvl_idx[z_lvl_qos] = phase_stop_4
+                        z_lvl_qos += 1
+                        y_lvl_q += 1
+                        break
                     end
-                    i = phase_stop_3 + 1
                 end
                 x_lvl_2_val = x_lvl_val[x_lvl_q]
                 if y_lvl_idx[y_lvl_q] < phase_stop_2
                     y_lvl_q = Finch.scansearch(y_lvl_idx, phase_stop_2, y_lvl_q, y_lvl_q_stop - 1)
                 end
                 y_lvl_i = y_lvl_idx[y_lvl_q]
-                phase_stop_4 = min(y_lvl_i, phase_stop_2)
-                if y_lvl_i == phase_stop_4
-                    for i_10 = phase_stop_2:phase_stop_4 - 1
+                if y_lvl_i < phase_stop_2
+                    for i_11 = phase_stop_2:y_lvl_i - 1
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
                             Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
@@ -84,7 +95,7 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = i_10
+                        z_lvl_idx[z_lvl_qos] = i_11
                         z_lvl_qos += 1
                     end
                     y_lvl_2_val = y_lvl_val[y_lvl_q]
@@ -95,21 +106,49 @@ quote
                         Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                     end
                     z_lvl_val[z_lvl_qos] = x_lvl_2_val + y_lvl_2_val
-                    z_lvl_idx[z_lvl_qos] = phase_stop_4
+                    z_lvl_idx[z_lvl_qos] = y_lvl_i
                     z_lvl_qos += 1
                     y_lvl_q += 1
                 else
-                    for i_12 = phase_stop_2:phase_stop_4
+                    phase_stop_6 = min(y_lvl_i, phase_stop_2)
+                    if y_lvl_i == phase_stop_6
+                        for i_13 = phase_stop_2:phase_stop_6 - 1
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = i_13
+                            z_lvl_qos += 1
+                        end
+                        y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
                             Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
                             Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
-                        z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = i_12
+                        z_lvl_val[z_lvl_qos] = x_lvl_2_val + y_lvl_2_val
+                        z_lvl_idx[z_lvl_qos] = phase_stop_6
                         z_lvl_qos += 1
+                        y_lvl_q += 1
+                    else
+                        for i_15 = phase_stop_2:phase_stop_6
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val
+                            z_lvl_idx[z_lvl_qos] = i_15
+                            z_lvl_qos += 1
+                        end
                     end
+                    x_lvl_q += 1
+                    break
                 end
                 x_lvl_q += 1
             else
@@ -122,8 +161,8 @@ quote
                 while i <= phase_stop_2
                     y_lvl_i = y_lvl_idx[y_lvl_q]
                     x_lvl_i2 = x_lvl_idx[x_lvl_q]
-                    phase_stop_5 = min(x_lvl_i2, y_lvl_i, phase_stop_2)
-                    if y_lvl_i == phase_stop_5 && x_lvl_i2 == phase_stop_5
+                    phase_stop_7 = min(x_lvl_i2, y_lvl_i, phase_stop_2)
+                    if y_lvl_i == phase_stop_7 && x_lvl_i2 == phase_stop_7
                         x_lvl_2_val = x_lvl_val[x_lvl_q]
                         y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
@@ -133,11 +172,11 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val + y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_5
+                        z_lvl_idx[z_lvl_qos] = phase_stop_7
                         z_lvl_qos += 1
                         y_lvl_q += 1
                         x_lvl_q += 1
-                    elseif x_lvl_i2 == phase_stop_5
+                    elseif x_lvl_i2 == phase_stop_7
                         x_lvl_2_val = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -146,10 +185,10 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_5
+                        z_lvl_idx[z_lvl_qos] = phase_stop_7
                         z_lvl_qos += 1
                         x_lvl_q += 1
-                    elseif y_lvl_i == phase_stop_5
+                    elseif y_lvl_i == phase_stop_7
                         y_lvl_2_val = y_lvl_val[y_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -158,27 +197,27 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = y_lvl_2_val
-                        z_lvl_idx[z_lvl_qos] = phase_stop_5
+                        z_lvl_idx[z_lvl_qos] = phase_stop_7
                         z_lvl_qos += 1
                         y_lvl_q += 1
                     end
-                    i = phase_stop_5 + 1
+                    i = phase_stop_7 + 1
                 end
             end
             i = phase_stop_2 + 1
         end
     end
     phase_start_6 = max(1, 1 + y_lvl_i1)
-    phase_stop_6 = min(y_lvl.shape, x_lvl_i1)
-    if phase_stop_6 >= phase_start_6
+    phase_stop_8 = min(y_lvl.shape, x_lvl_i1)
+    if phase_stop_8 >= phase_start_6
         i = phase_start_6
-        while i <= phase_stop_6
+        while i <= phase_stop_8
             if x_lvl_idx[x_lvl_q] < i
                 x_lvl_q = Finch.scansearch(x_lvl_idx, i, x_lvl_q, x_lvl_q_stop - 1)
             end
             x_lvl_i2 = x_lvl_idx[x_lvl_q]
-            phase_stop_7 = min(x_lvl_i2, phase_stop_6)
-            if x_lvl_i2 == phase_stop_7
+            phase_stop_9 = min(x_lvl_i2, phase_stop_8)
+            if x_lvl_i2 == phase_stop_9
                 x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
                 if z_lvl_qos > z_lvl_qos_stop
                     z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -187,17 +226,16 @@ quote
                     Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                 end
                 z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
-                z_lvl_idx[z_lvl_qos] = phase_stop_7
+                z_lvl_idx[z_lvl_qos] = phase_stop_9
                 z_lvl_qos += 1
                 x_lvl_q += 1
             else
                 if x_lvl_idx[x_lvl_q] < i
                     x_lvl_q = Finch.scansearch(x_lvl_idx, i, x_lvl_q, x_lvl_q_stop - 1)
                 end
-                while i <= phase_stop_7
+                while true
                     x_lvl_i2 = x_lvl_idx[x_lvl_q]
-                    phase_stop_8 = min(x_lvl_i2, phase_stop_7)
-                    if x_lvl_i2 == phase_stop_8
+                    if x_lvl_i2 < phase_stop_9
                         x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
                         if z_lvl_qos > z_lvl_qos_stop
                             z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -206,27 +244,40 @@ quote
                             Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                         end
                         z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
-                        z_lvl_idx[z_lvl_qos] = phase_stop_8
+                        z_lvl_idx[z_lvl_qos] = x_lvl_i2
                         z_lvl_qos += 1
                         x_lvl_q += 1
+                    else
+                        phase_stop_11 = min(x_lvl_i2, phase_stop_9)
+                        if x_lvl_i2 == phase_stop_11
+                            x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
+                            if z_lvl_qos > z_lvl_qos_stop
+                                z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                                Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                                Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                                Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                            end
+                            z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
+                            z_lvl_idx[z_lvl_qos] = phase_stop_11
+                            z_lvl_qos += 1
+                            x_lvl_q += 1
+                        end
+                        break
                     end
-                    i = phase_stop_8 + 1
                 end
             end
-            i = phase_stop_7 + 1
+            i = phase_stop_9 + 1
         end
     end
     phase_start_9 = max(1, 1 + x_lvl_i1)
-    phase_stop_9 = min(y_lvl.shape, y_lvl_i1)
-    if phase_stop_9 >= phase_start_9
-        i = phase_start_9
+    phase_stop_12 = min(y_lvl.shape, y_lvl_i1)
+    if phase_stop_12 >= phase_start_9
         if y_lvl_idx[y_lvl_q] < phase_start_9
             y_lvl_q = Finch.scansearch(y_lvl_idx, phase_start_9, y_lvl_q, y_lvl_q_stop - 1)
         end
-        while i <= phase_stop_9
+        while true
             y_lvl_i = y_lvl_idx[y_lvl_q]
-            phase_stop_10 = min(y_lvl_i, phase_stop_9)
-            if y_lvl_i == phase_stop_10
+            if y_lvl_i < phase_stop_12
                 y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
                 if z_lvl_qos > z_lvl_qos_stop
                     z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -235,11 +286,26 @@ quote
                     Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                 end
                 z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
-                z_lvl_idx[z_lvl_qos] = phase_stop_10
+                z_lvl_idx[z_lvl_qos] = y_lvl_i
                 z_lvl_qos += 1
                 y_lvl_q += 1
+            else
+                phase_stop_14 = min(y_lvl_i, phase_stop_12)
+                if y_lvl_i == phase_stop_14
+                    y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
+                    if z_lvl_qos > z_lvl_qos_stop
+                        z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                        Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                        Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                    end
+                    z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
+                    z_lvl_idx[z_lvl_qos] = phase_stop_14
+                    z_lvl_qos += 1
+                    y_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_10 + 1
         end
     end
     z_lvl_ptr[1 + 1] = (z_lvl_qos - 0) - 1
@@ -258,5 +324,5 @@ julia> @finch begin
             z[i] = x[gallop(i)] + y[i]
         end
     end
-(z = Fiber(SparseList{Int64}(Element{0.0, Float64, Int64}([2.0, 1.0, 3.0, 5.0, 5.0, 1.0, 6.0]), 10, [1, 8], [1, 2, 3, 5, 7, 8, 9])),)
+(z = Fiber(SparseList{Int64}(Element{0.0, Float64, Int64}([1.0, 2.0, 6.0]), 10, [1, 4], [0, 1, 9])),)
 

--- a/test/reference64/typical_merge_twofinger.txt
+++ b/test/reference64/typical_merge_twofinger.txt
@@ -96,14 +96,12 @@ quote
     phase_start_3 = max(1, 1 + y_lvl_i1)
     phase_stop_3 = min(y_lvl.shape, x_lvl_i1)
     if phase_stop_3 >= phase_start_3
-        i = phase_start_3
         if x_lvl_idx[x_lvl_q] < phase_start_3
             x_lvl_q = Finch.scansearch(x_lvl_idx, phase_start_3, x_lvl_q, x_lvl_q_stop - 1)
         end
-        while i <= phase_stop_3
+        while true
             x_lvl_i = x_lvl_idx[x_lvl_q]
-            phase_stop_4 = min(x_lvl_i, phase_stop_3)
-            if x_lvl_i == phase_stop_4
+            if x_lvl_i < phase_stop_3
                 x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
                 if z_lvl_qos > z_lvl_qos_stop
                     z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -112,24 +110,37 @@ quote
                     Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                 end
                 z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
-                z_lvl_idx[z_lvl_qos] = phase_stop_4
+                z_lvl_idx[z_lvl_qos] = x_lvl_i
                 z_lvl_qos += 1
                 x_lvl_q += 1
+            else
+                phase_stop_5 = min(x_lvl_i, phase_stop_3)
+                if x_lvl_i == phase_stop_5
+                    x_lvl_2_val_2 = x_lvl_val[x_lvl_q]
+                    if z_lvl_qos > z_lvl_qos_stop
+                        z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                        Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                        Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                    end
+                    z_lvl_val[z_lvl_qos] = x_lvl_2_val_2
+                    z_lvl_idx[z_lvl_qos] = phase_stop_5
+                    z_lvl_qos += 1
+                    x_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_4 + 1
         end
     end
     phase_start_5 = max(1, 1 + x_lvl_i1)
-    phase_stop_5 = min(y_lvl.shape, y_lvl_i1)
-    if phase_stop_5 >= phase_start_5
-        i = phase_start_5
+    phase_stop_6 = min(y_lvl.shape, y_lvl_i1)
+    if phase_stop_6 >= phase_start_5
         if y_lvl_idx[y_lvl_q] < phase_start_5
             y_lvl_q = Finch.scansearch(y_lvl_idx, phase_start_5, y_lvl_q, y_lvl_q_stop - 1)
         end
-        while i <= phase_stop_5
+        while true
             y_lvl_i = y_lvl_idx[y_lvl_q]
-            phase_stop_6 = min(y_lvl_i, phase_stop_5)
-            if y_lvl_i == phase_stop_6
+            if y_lvl_i < phase_stop_6
                 y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
                 if z_lvl_qos > z_lvl_qos_stop
                     z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
@@ -138,11 +149,26 @@ quote
                     Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
                 end
                 z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
-                z_lvl_idx[z_lvl_qos] = phase_stop_6
+                z_lvl_idx[z_lvl_qos] = y_lvl_i
                 z_lvl_qos += 1
                 y_lvl_q += 1
+            else
+                phase_stop_8 = min(y_lvl_i, phase_stop_6)
+                if y_lvl_i == phase_stop_8
+                    y_lvl_2_val_2 = y_lvl_val[y_lvl_q]
+                    if z_lvl_qos > z_lvl_qos_stop
+                        z_lvl_qos_stop = max(z_lvl_qos_stop << 1, 1)
+                        Finch.resize_if_smaller!(z_lvl_idx, z_lvl_qos_stop)
+                        Finch.resize_if_smaller!(z_lvl_val, z_lvl_qos_stop)
+                        Finch.fill_range!(z_lvl_val, 0.0, z_lvl_qos, z_lvl_qos_stop)
+                    end
+                    z_lvl_val[z_lvl_qos] = y_lvl_2_val_2
+                    z_lvl_idx[z_lvl_qos] = phase_stop_8
+                    z_lvl_qos += 1
+                    y_lvl_q += 1
+                end
+                break
             end
-            i = phase_stop_6 + 1
         end
     end
     z_lvl_ptr[1 + 1] = (z_lvl_qos - 0) - 1

--- a/test/reference64/typical_spmv_csc.txt
+++ b/test/reference64/typical_spmv_csc.txt
@@ -54,20 +54,26 @@ quote
         end
         phase_stop = min(A_lvl_2.shape, A_lvl_2_i1)
         if phase_stop >= 1
-            i = 1
             if A_lvl_idx[A_lvl_2_q] < 1
                 A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                if A_lvl_2_i == phase_stop_2
+                if A_lvl_2_i < phase_stop
                     A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
-                    y_lvl_q = (1 - 1) * A_lvl_2.shape + phase_stop_2
+                    y_lvl_q = (1 - 1) * A_lvl_2.shape + A_lvl_2_i
                     y_lvl_val[y_lvl_q] = x_lvl_2_val * A_lvl_3_val + y_lvl_val[y_lvl_q]
                     A_lvl_2_q += 1
+                else
+                    phase_stop_3 = min(A_lvl_2_i, phase_stop)
+                    if A_lvl_2_i == phase_stop_3
+                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                        y_lvl_q = (1 - 1) * A_lvl_2.shape + phase_stop_3
+                        y_lvl_val[y_lvl_q] = x_lvl_2_val * A_lvl_3_val + y_lvl_val[y_lvl_q]
+                        A_lvl_2_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
     end

--- a/test/reference64/typical_spmv_sparsematrixcsc.txt
+++ b/test/reference64/typical_spmv_sparsematrixcsc.txt
@@ -45,19 +45,24 @@ quote
         end
         phase_stop = min(A_i1, A.m)
         if phase_stop >= 1
-            i = 1
             if A.rowval[A_q] < 1
                 A_q = Finch.scansearch(A.rowval, 1, A_q, A_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 A_i = A.rowval[A_q]
-                phase_stop_2 = min(phase_stop, A_i)
-                if A_i == phase_stop_2
+                if A_i < phase_stop
                     A_val = A.nzval[A_q]
-                    y[phase_stop_2] = x[j_4] * A_val + y[phase_stop_2]
+                    y[A_i] = x[j_4] * A_val + y[A_i]
                     A_q += 1
+                else
+                    phase_stop_3 = min(A_i, phase_stop)
+                    if A_i == phase_stop_3
+                        A_val = A.nzval[A_q]
+                        y[phase_stop_3] = x[j_4] * A_val + y[phase_stop_3]
+                        A_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
     end

--- a/test/reference64/typical_stats_example.txt
+++ b/test/reference64/typical_stats_example.txt
@@ -47,11 +47,10 @@ quote
         if X_lvl_idx[X_lvl_q] < 1
             X_lvl_q = Finch.scansearch(X_lvl_idx, 1, X_lvl_q, X_lvl_q_stop - 1)
         end
-        while i <= phase_stop
+        while true
             X_lvl_i = X_lvl_idx[X_lvl_q]
-            phase_stop_2 = min(phase_stop, X_lvl_i)
-            if X_lvl_i == phase_stop_2
-                cond = 0 < -i + phase_stop_2
+            if X_lvl_i < phase_stop
+                cond = 0 < -i + X_lvl_i
                 if cond
                     x_min_val = min(0.0, x_min_val)
                     x_max_val = max(0.0, x_max_val)
@@ -62,21 +61,38 @@ quote
                 x_sum_val = X_lvl_2_val + x_sum_val
                 x_var_val = X_lvl_2_val * X_lvl_2_val + x_var_val
                 X_lvl_q += 1
+                i = X_lvl_i + 1
             else
-                cond_2 = 0 < 1 + -i + phase_stop_2
-                if cond_2
-                    x_min_val = min(0.0, x_min_val)
-                    x_max_val = max(0.0, x_max_val)
+                phase_stop_3 = min(X_lvl_i, phase_stop)
+                if X_lvl_i == phase_stop_3
+                    cond_2 = 0 < -i + phase_stop_3
+                    if cond_2
+                        x_min_val = min(0.0, x_min_val)
+                        x_max_val = max(0.0, x_max_val)
+                    end
+                    X_lvl_2_val = X_lvl_val[X_lvl_q]
+                    x_min_val = min(X_lvl_2_val, x_min_val)
+                    x_max_val = max(X_lvl_2_val, x_max_val)
+                    x_sum_val = X_lvl_2_val + x_sum_val
+                    x_var_val = X_lvl_2_val * X_lvl_2_val + x_var_val
+                    X_lvl_q += 1
+                else
+                    cond_3 = 0 < 1 + -i + phase_stop_3
+                    if cond_3
+                        x_min_val = min(0.0, x_min_val)
+                        x_max_val = max(0.0, x_max_val)
+                    end
                 end
+                i = phase_stop_3 + 1
+                break
             end
-            i = phase_stop_2 + 1
         end
     end
     phase_start_3 = max(1, 1 + X_lvl_i1)
-    phase_stop_3 = X_lvl.shape
-    if phase_stop_3 >= phase_start_3
-        cond_3 = 0 < 1 + -phase_start_3 + phase_stop_3
-        if cond_3
+    phase_stop_4 = X_lvl.shape
+    if phase_stop_4 >= phase_start_3
+        cond_4 = 0 < 1 + -phase_start_3 + phase_stop_4
+        if cond_4
             x_min_val = min(0.0, x_min_val)
             x_max_val = max(0.0, x_max_val)
         end

--- a/test/reference64/typical_transpose_csc_to_coo.txt
+++ b/test/reference64/typical_transpose_csc_to_coo.txt
@@ -47,16 +47,14 @@ quote
         end
         phase_stop = min(A_lvl_2_i1, A_lvl_2.shape)
         if phase_stop >= 1
-            i = 1
             if A_lvl_idx[A_lvl_2_q] < 1
                 A_lvl_2_q = Finch.scansearch(A_lvl_idx, 1, A_lvl_2_q, A_lvl_2_q_stop - 1)
             end
-            while i <= phase_stop
+            while true
                 A_lvl_2_i = A_lvl_idx[A_lvl_2_q]
-                phase_stop_2 = min(phase_stop, A_lvl_2_i)
-                if A_lvl_2_i == phase_stop_2
+                if A_lvl_2_i < phase_stop
                     A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
-                    B_lvl_key_2 = (1, (j_4, phase_stop_2))
+                    B_lvl_key_2 = (1, (j_4, A_lvl_2_i))
                     B_lvl_q_2 = get(B_lvl_tbl, B_lvl_key_2, B_lvl_qos_fill + 1)
                     if B_lvl_q_2 > B_lvl_qos_stop
                         B_lvl_qos_stop = max(B_lvl_qos_stop << 1, 1)
@@ -70,8 +68,27 @@ quote
                         B_lvl_ptr[1 + 1] += 1
                     end
                     A_lvl_2_q += 1
+                else
+                    phase_stop_3 = min(A_lvl_2_i, phase_stop)
+                    if A_lvl_2_i == phase_stop_3
+                        A_lvl_3_val = A_lvl_2_val[A_lvl_2_q]
+                        B_lvl_key_3 = (1, (j_4, phase_stop_3))
+                        B_lvl_q_3 = get(B_lvl_tbl, B_lvl_key_3, B_lvl_qos_fill + 1)
+                        if B_lvl_q_3 > B_lvl_qos_stop
+                            B_lvl_qos_stop = max(B_lvl_qos_stop << 1, 1)
+                            Finch.resize_if_smaller!(B_lvl_val, B_lvl_qos_stop)
+                            Finch.fill_range!(B_lvl_val, 0.0, B_lvl_q_3, B_lvl_qos_stop)
+                        end
+                        B_lvl_val[B_lvl_q_3] = A_lvl_3_val
+                        if B_lvl_q_3 > B_lvl_qos_fill
+                            B_lvl_qos_fill = B_lvl_q_3
+                            B_lvl_tbl[B_lvl_key_3] = B_lvl_q_3
+                            B_lvl_ptr[1 + 1] += 1
+                        end
+                        A_lvl_2_q += 1
+                    end
+                    break
                 end
-                i = phase_stop_2 + 1
             end
         end
     end


### PR DESCRIPTION
This allows us to emit a fast stepper loop even when we can't prove that A_lvl_i <= phase_stop, by using the loop guard to ensure the property as well as check when we need to break. Ideally we could consolidate the logic inside the stepper. fixes #308