### PR TITLE
Swizzle back in `copyto!`

### DIFF
--- a/src/interface/copy.jl
+++ b/src/interface/copy.jl
@@ -28,13 +28,11 @@ function permutedims(src::Tensor, perm)
 end
 
 function Base.copyto!(dst::Union{Tensor, AbstractArray}, src::SwizzleArray{dims}) where {dims}
-    ret = copyto!(swizzle(dst, invperm(dims)...), src.body)
-    return ret
+    return copyto!(swizzle(dst, invperm(dims)...), src.body)
 end
 
 function Base.copyto!(dst::SwizzleArray{dims1}, src::SwizzleArray{dims2}) where {dims1, dims2}
-    ret = copyto!(swizzle(dst, invperm(dims2)[collect(dims1)]...), src.body)
-    return ret
+    return copyto!(swizzle(dst, invperm(dims2)[collect(dims1)]...), src.body)
 end
 
 function Base.copyto!(dst::SwizzleArray{dims}, src::Union{Tensor, AbstractArray}) where {dims}

--- a/src/interface/copy.jl
+++ b/src/interface/copy.jl
@@ -24,24 +24,23 @@ end
 
 function permutedims(src::Tensor, perm)
     dst = similar(src)
-    copyto!(dst, swizzle(src, perm...))
+    return copyto!(dst, swizzle(src, perm...))
 end
 
 function Base.copyto!(dst::Union{Tensor, AbstractArray}, src::SwizzleArray{dims}) where {dims}
     ret = copyto!(swizzle(dst, invperm(dims)...), src.body)
-    return ret.body
+    return ret
 end
 
 function Base.copyto!(dst::SwizzleArray{dims1}, src::SwizzleArray{dims2}) where {dims1, dims2}
-    println(invperm(dims2)[collect(dims1)])
     ret = copyto!(swizzle(dst, invperm(dims2)[collect(dims1)]...), src.body)
-    return ret.body
+    return ret
 end
 
 function Base.copyto!(dst::SwizzleArray{dims}, src::Union{Tensor, AbstractArray}) where {dims}
     tmp = Tensor(SparseHash{ndims(src)}(Element(default(src))))
     tmp = copyto_helper!(swizzle(tmp, dims...), src)
-    swizzle(copyto_helper!(dst.body, tmp), dims...)
+    return copyto_helper!(swizzle(dst.body, dims...), tmp)
 end
 
 dropdefaults(src) = dropdefaults!(similar(src), src)

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -593,4 +593,22 @@ using CIndices
         @finch let a=1, b=2; c[] += a + b end
         @test c[] == 3
     end
+
+    #https://github.com/willow-ahrens/Finch.jl/issues/387
+    let
+        A = zeros(2, 4, 3)
+        A[1,:,:] = [0.0 0.0 4.4; 1.1 0.0 0.0; 0.0 0.0 0.0; 3.3 0.0 0.0]
+        A[2,:,:] = [1.0 0.0 0.0; 0.0 0.0 0.0; 0.0 1.0 0.0; 3.3 0.0 0.0]
+
+        for p in [(1, 2, 3), (3, 2, 1), (3, 1, 2), (1, 3, 2), (2, 3, 1)]
+            expected = permutedims(A, p)
+
+            t = Tensor(Dense(Dense(Dense(Element(0.0)))), A)
+            actual = Finch.permutedims(t, p)
+
+            @test size(expected) == size(actual)
+            @test vcat(expected...) == actual.lvl.lvl.lvl.lvl.val
+        end
+    end
+
 end


### PR DESCRIPTION
Hi @willow-ahrens,

I took a look at #387 and I think that `return ret.body` causes omitting "swizzling" back to the desired dimensionality in some `copyto!` functions. I just started learning how it works so I might have misunderstood it.

fixes #387