### PR TITLE
API: Introduce `OffByOneVector`

### DIFF
--- a/docs/src/guides/interoperability.md
+++ b/docs/src/guides/interoperability.md
@@ -16,11 +16,51 @@ Julia](https://docs.julialang.org/en/v1/manual/embedding/#Working-with-Arrays).
 
 However, for sparse array formats, it's not just a matter of subtracting one
 from the index, as the internal lists of indices, positions, etc all start from
-zero as well. To remedy the situation, Finch interoperates with the
-[CIndices](https://github.com/JuliaSparse/CIndices.jl) package, which exports a 
-type called `CIndex`. The internal representation of `CIndex` is one less than the
-value it represents, and we can use `CIndex` as the index or position type of
-a Finch array to represent arrays in other languages.
+zero as well. To remedy the situation, Finch leverages `OffByOneVector` and `CIndex`.
+
+### `OffByOneVector`
+
+`OffByOneVector` is a view that adds `1` on access to an underlying 0-Index vector.
+This allows to use Python/NumPy vector, without copying, as a mutable index array.
+
+```jldoctest example2; setup = :(using Finch)
+julia> v = Vector([1, 0, 2, 3])
+4-element Vector{Int64}:
+ 1
+ 0
+ 2
+ 3
+julia> obov = OffByOneVector(v)
+4-element OffByOneVector{Int64}:
+ 2
+ 1
+ 3
+ 4
+julia> obov[1] += 8
+10
+julia> obov
+4-element OffByOneVector{Int64}:
+ 10
+  1
+  3
+  4
+julia> obov.data
+4-element Vector{Int64}:
+ 9
+ 0
+ 2
+ 3
+```
+
+### `CIndex`
+
+!!! warning
+    `CIndex` is no longer recommended - use `OffByOneVector` instead.
+
+Finch also interoperates with the [CIndices](https://github.com/JuliaSparse/CIndices.jl)
+package, which exports a type called `CIndex`. The internal representation of `CIndex`
+is one less than the value it represents, and we can use `CIndex` as the index or
+position type of a Finch array to represent arrays in other languages.
 
 For example, if `idx_c`, `ptr_c`, and `val_c` are the internal arrays of a CSC
 matrix in a zero-indexed language, we can represent that matrix as a one-indexed
@@ -59,4 +99,4 @@ Dense [:,1:3]
 │ ├─[CIndex{Int64}(3)]: 5.5
 ```
 
-We can also convert between representations by by copying to or from `CIndex` fibers.
+We can also convert between representations by copying to or from `CIndex` fibers.

--- a/src/Finch.jl
+++ b/src/Finch.jl
@@ -42,6 +42,7 @@ export walk, gallop, follow, extrude, laminate
 export Tensor, pattern!, dropdefaults, dropdefaults!, redefault!
 export diagmask, lotrimask, uptrimask, bandmask
 export scale, product, offset, permissive, protocolize, swizzle, toeplitz, window
+export OffByOneVector
 
 export choose, minby, maxby, overwrite, initwrite, d
 
@@ -103,6 +104,7 @@ include("looplets/fills.jl")
 include("tensors/scalars.jl")
 include("tensors/levels/abstractlevel.jl")
 include("tensors/fibers.jl")
+include("tensors/vectors.jl")
 include("tensors/levels/sparserlelevels.jl")
 include("tensors/levels/singlerlelevels.jl")
 include("tensors/levels/sparselistlevels.jl")

--- a/src/interface/fileio/binsparse.jl
+++ b/src/interface/fileio/binsparse.jl
@@ -245,10 +245,9 @@ bspread_format_lookup = OrderedDict(
 
 bspwrite_format_lookup = OrderedDict(v => k for (k, v) in bspread_format_lookup)
 
-#indices_zero_to_one(vec::Vector{Ti}) where {Ti} = unsafe_wrap(Array, reinterpret(Ptr{CIndex{Ti}}, pointer(vec)), length(vec); own = true)
+#indices_zero_to_one(vec::Vector{Ti}) where {Ti} = OffByOneVector(vec)
 indices_zero_to_one(vec::Vector) = vec .+ one(eltype(vec))
 indices_one_to_zero(vec::Vector) = vec .- one(eltype(vec))
-#indices_one_to_zero(vec::Vector{<:CIndex{Ti}}) where {Ti} = unsafe_wrap(Array, reinterpret(Ptr{Ti}, pointer(vec)), length(vec); own = true)
 
 struct NPYPath
     dirname::String

--- a/src/tensors/vectors.jl
+++ b/src/tensors/vectors.jl
@@ -1,0 +1,36 @@
+using Base: @propagate_inbounds
+
+struct OffByOneVector{T} <: AbstractVector{T}
+    data::AbstractVector{T}
+end
+
+@propagate_inbounds function Base.getindex(vector::OffByOneVector{T},
+                                           index::Int) where {T}
+    return vector.data[index] + 0x01
+end
+
+@propagate_inbounds function Base.getindex(vector::OffByOneVector{T},
+                                           index::Vararg{Int}) where {T}
+    return vector.data[index...] + 0x01
+end
+
+@propagate_inbounds function Base.setindex!(vector::OffByOneVector{T},
+                                            val::T,
+                                            index::Int) where {T}
+    vector.data[index] = val - 0x01
+end
+
+@propagate_inbounds function Base.setindex!(vector::OffByOneVector{T},
+                                            val::T,
+                                            index::Vararg{Int}) where {T}
+    vector.data[index...] = val - 0x01
+end
+
+Base.parent(vector::OffByOneVector{T}) where {T} = vector.data
+Base.size(vector::OffByOneVector{T}) where {T} = size(vector.data)
+Base.axes(vector::OffByOneVector{T}) where {T} = axes(vector.data)
+
+function moveto(vector::OffByOneVector{T}, device) where {T}
+    data = moveto(vector.data, device)
+    return OffByOneVector{T}(data)
+end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -176,9 +176,9 @@ using CIndices
     let 
         m = 4; n = 3; ptr_c = [0, 3, 3, 5]; idx_c = [1, 2, 3, 0, 2]; val_c = [1.1, 2.2, 3.3, 4.4, 5.5];
 
-        ptr_jl = unsafe_wrap(Array, reinterpret(Ptr{CIndex{Int}}, pointer(ptr_c)), length(ptr_c); own = false)
-        idx_jl = unsafe_wrap(Array, reinterpret(Ptr{CIndex{Int}}, pointer(idx_c)), length(idx_c); own = false)
-        A = Tensor(Dense(SparseList{CIndex{Int}}(Element{0.0, Float64, CIndex{Int}}(val_c), m, ptr_jl, idx_jl), n))
+        ptr_jl = OffByOneVector(ptr_c)
+        idx_jl = OffByOneVector(idx_c)
+        A = Tensor(Dense(SparseList{Int}(Element{0.0, Float64, Int}(val_c), m, ptr_jl, idx_jl), n))
 
         @test A == [0.0 0.0 4.4; 1.1 0.0 0.0; 2.2 0.0 5.5; 3.3 0.0 0.0]
     end


### PR DESCRIPTION
Addresses: https://github.com/willow-ahrens/Finch.jl/issues/381

Hi @willow-ahrens @hameerabbasi,

This PR adds the `OffByOneVector` struct that allows to use NumPy arrays as indices arrays without a copy. 