### PR TITLE
API: Add `eltype` for `SwizzleArray`

### DIFF
--- a/src/tensors/combinators/swizzle.jl
+++ b/src/tensors/combinators/swizzle.jl
@@ -7,6 +7,7 @@ SwizzleArray{dims}(body::Body) where {dims, Body} = SwizzleArray{dims, Body}(bod
 
 Base.ndims(arr::SwizzleArray) = ndims(typeof(arr))
 Base.ndims(::Type{SwizzleArray{dims, Body}}) where {dims, Body} = ndims(Body)
+Base.eltype(arr::SwizzleArray) = eltype(arr.body)
 default(arr::SwizzleArray) = default(typeof(arr))
 default(::Type{SwizzleArray{dims, Body}}) where {dims, Body} = default(Body)
 


### PR DESCRIPTION
Hi @willow-ahrens,

Just a nitpick one-line change that I noticed in `Tensor` class in `finch-tensor`.