### PR TITLE
API: Add list indexing for 1D Tensors

### DIFF
--- a/src/interface/index.jl
+++ b/src/interface/index.jl
@@ -25,6 +25,7 @@ getindex_rep_def(lvl::RepeatData, idx::Drop) = SolidData(ElementData(lvl.default
 getindex_rep_def(lvl::RepeatData, idx) = SolidData(ElementData(lvl.default, lvl.eltype))
 getindex_rep_def(lvl::RepeatData, idx::Type{<:AbstractUnitRange}) = SolidData(ElementData(lvl.default, lvl.eltype))
 
+Base.getindex(arr::Tensor, inds::AbstractVector) = getindex_helper(arr, to_indices(arr, axes(arr), (inds,)))
 Base.getindex(arr::Tensor, inds...) = getindex_helper(arr, to_indices(arr, inds))
 @staged function getindex_helper(arr, inds)
     inds <: Type{<:Tuple}

--- a/src/tensors/combinators/swizzle.jl
+++ b/src/tensors/combinators/swizzle.jl
@@ -12,6 +12,8 @@ Base.eltype(::Type{SwizzleArray{dims, Body}}) where {dims, Body} = eltype(Body)
 default(arr::SwizzleArray) = default(typeof(arr))
 default(::Type{SwizzleArray{dims, Body}}) where {dims, Body} = default(Body)
 
+Base.to_indices(A::SwizzleArray, I::Tuple{AbstractVector}) = Base.to_indices(A, axes(A), I)
+
 function Base.getindex(arr::SwizzleArray{perm}, inds...) where {perm}
     inds_2 = Base.to_indices(arr, inds)
     perm_2 = collect(invperm(perm))

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -634,4 +634,15 @@ using CIndices
         A = AsArray(swizzle(Tensor(Dense(Dense(Element(0.0))), [1 2 3; 4 5 6; 7 8 9]), 2, 1))
         check_output("print_swizzle_as_array.txt", sprint(show, MIME"text/plain"(), A))
     end
+
+    #https://github.com/willow-ahrens/Finch.jl/issues/427
+    let
+        a = [1, 2, 0, 0, 1]
+        a_fbr = Tensor(Dense(Element(0)), a)
+        a_sw = swizzle(a_fbr, 1)
+        idx = [1, 1, 3]
+
+        @test a[idx] == a_fbr[idx]
+        @test a[idx] == a_sw[idx]
+    end
 end


### PR DESCRIPTION
Addressing #427

Hi @willow-ahrens,

This PR adds specialized `getindex` and `to_indices` for `Tensor` and `SwizzleArray`, to enable list indexing for 1D objects.
There's no need to check whether `Tensor`/`SwizzleArray` is 1D here, because indexing +2D `Tensor` with a list/vector results in `AssertionError: ndims(arr) == length(inds)`. 
