### PR TITLE
Fix SingleList

### DIFF
--- a/src/tensors/levels/singlelistlevels.jl
+++ b/src/tensors/levels/singlelistlevels.jl
@@ -292,9 +292,9 @@ function instantiate(fbr::VirtualSubFiber{VirtualSingleListLevel}, ctx, mode::Re
                 Phase(
                     start = (ctx, ext) -> literal(lvl.Ti(1)),
                     stop = (ctx, ext) -> value(my_i),
-                    body = (ctx, ext) -> Spike(
+                    body = (ctx, ext) -> truncate(Spike(
                             body = Fill(virtual_level_default(lvl)),
-                            tail = instantiate(VirtualSubFiber(lvl.lvl, value(my_q, Ti)), ctx, mode, subprotos))
+                            tail = instantiate(VirtualSubFiber(lvl.lvl, value(my_q, Ti)), ctx, mode, subprotos)), ctx, similar_extent(ext, getstart(ext), value(my_i)), ext)
                 ),
                 Phase(
                     stop = (ctx, ext) -> lvl.shape,


### PR DESCRIPTION
This fixes #444 .

Now the generated code looks like this. I want to remove all the empty switch cases but it is hard to filter out in Finch AST level because we can know whether the body of case is empty or not after the dead code elimination:

```
quote
    s = ((ex.bodies[1]).bodies[1]).tns.bind
    x_lvl = (((ex.bodies[1]).bodies[2]).body.rhs.args[1]).tns.bind.lvl
    x_lvl_ptr = x_lvl.ptr
    x_lvl_idx = x_lvl.idx
    x_lvl_val = x_lvl.lvl.val
    y_lvl = (((ex.bodies[1]).bodies[2]).body.rhs.args[2]).tns.bind.lvl
    y_lvl_ptr = y_lvl.ptr
    y_lvl_idx = y_lvl.idx
    y_lvl_val = y_lvl.lvl.val
    y_lvl.shape == x_lvl.shape || throw(DimensionMismatch("mismatched dimension limits ($(y_lvl.shape) != $(x_lvl.shape))"))
    result = nothing
    s_val = 0
    y_lvl_q = y_lvl_ptr[1]
    y_lvl_q_stop = y_lvl_ptr[1 + 1]
    if y_lvl_q < y_lvl_q_stop
        y_lvl_i = y_lvl_idx[y_lvl_q]
    else
        y_lvl_i = 0
    end
    x_lvl_q = x_lvl_ptr[1]
    x_lvl_q_stop = x_lvl_ptr[1 + 1]
    if x_lvl_q < x_lvl_q_stop
        x_lvl_i = x_lvl_idx[x_lvl_q]
    else
        x_lvl_i = 0
    end
    phase_stop = min(y_lvl.shape, y_lvl_i, x_lvl_i)
    if phase_stop >= 1
        if phase_stop < y_lvl_i && phase_stop < x_lvl_i
        elseif phase_stop < x_lvl_i
        elseif phase_stop < y_lvl_i
        else
            y_lvl_2_val = y_lvl_val[y_lvl_q]
            x_lvl_2_val = x_lvl_val[x_lvl_q]
            s_val = 0 + x_lvl_2_val * y_lvl_2_val
        end
    end
    s.val = s_val
    result = (s = s,)
    result
end
```