### PR TITLE
Fix sparsehash level follow

### DIFF
--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -692,4 +692,14 @@ using CIndices
             end
         end)
     end
+
+    let
+        A_hash = Tensor(SparseHash{1}(SparseHash{1}(Element(0.0))))
+        copyto!(A_hash, sprand(10, 10, 1))
+        B_hash = Tensor(SparseHash{1}(SparseHash{1}(Element(0.0))))
+        copyto!(B_hash, sprand(10, 10, 1))
+        output = Scalar(0)
+        @finch (output .= 0; for i=_, j=_ output[] += A_hash[j,i] * B_hash[follow(j), i] end)
+    end
+
 end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -694,10 +694,12 @@ using CIndices
     end
 
     let
+        A_COO = fsprand(10, 10, .5)
         A_hash = Tensor(SparseHash{1}(SparseHash{1}(Element(0.0))))
-        copyto!(A_hash, sprand(10, 10, 1))
+        @finch (A_hash .= 0; for i=_, j=_ A_hash[i,j]= A_COO[i,j] end)
+        B_COO = fsprand(10, 10, .5)
         B_hash = Tensor(SparseHash{1}(SparseHash{1}(Element(0.0))))
-        copyto!(B_hash, sprand(10, 10, 1))
+        @finch (B_hash .= 0; for i=_, j=_ B_hash[i,j]= B_COO[i,j] end)
         output = Scalar(0)
         @finch (output .= 0; for i=_, j=_ output[] += A_hash[j,i] * B_hash[follow(j), i] end)
     end


### PR DESCRIPTION
Currently the follow protocol throws an error for sparsehashlevel. I think that this level may be deprecated anyways, but the new level (SparseDict?) doesn't support follow yet. 

The fix is very simple, I just added "my_key = freshen(ctx.code, tag, :_key)"  to line 415. All other line changes are just formatting white space.