### PR TITLE
Fix `SwizzleArray` broadcasting

### DIFF
--- a/src/interface/copy.jl
+++ b/src/interface/copy.jl
@@ -31,6 +31,16 @@ function Base.permutedims(src::Tensor, perm)
     copyto!(dst, swizzle(src, perm...))
 end
 
+# I'm not sure if this is the right way for specializing types (breaking Union from below) but
+# without it there's:
+# MethodError: copyto!(::Vector{Float64}, ::Finch.SwizzleArray{(2, 3, 1), Tensor{DenseLevel{Int64,
+#   DenseLevel{Int64, DenseLevel{Int64, ElementLevel{0.0, Float64, Int64, Vector{Float64}}}}}}}) is ambiguous.
+#
+function Base.copyto!(dst::AbstractArray, src::SwizzleArray{dims}) where {dims}
+    ret = copyto!(swizzle(dst, invperm(dims)...), src.body)
+    return ret.body
+end
+
 function Base.copyto!(dst::Union{Tensor, AbstractArray}, src::SwizzleArray{dims}) where {dims}
     ret = copyto!(swizzle(dst, invperm(dims)...), src.body)
     return ret.body

--- a/src/tensors/combinators/swizzle.jl
+++ b/src/tensors/combinators/swizzle.jl
@@ -34,7 +34,6 @@ function Base.setindex!(arr::SwizzleArray{perm}, v, inds...) where {perm}
 end
 
 Base.size(arr::SwizzleArray{dims}) where {dims} = map(n->size(arr.body)[n], dims)
-Base.length(arr::SwizzleArray) = prod(size(arr))
 
 Base.show(io::IO, ex::SwizzleArray) = Base.show(io, MIME"text/plain"(), ex)
 function Base.show(io::IO, mime::MIME"text/plain", ex::SwizzleArray{dims}) where {dims}

--- a/src/tensors/combinators/swizzle.jl
+++ b/src/tensors/combinators/swizzle.jl
@@ -33,8 +33,8 @@ function Base.setindex!(arr::SwizzleArray{perm}, v, inds...) where {perm}
     arr
 end
 
-
 Base.size(arr::SwizzleArray{dims}) where {dims} = map(n->size(arr.body)[n], dims)
+Base.length(arr::SwizzleArray) = prod(size(arr))
 
 Base.show(io::IO, ex::SwizzleArray) = Base.show(io, MIME"text/plain"(), ex)
 function Base.show(io::IO, mime::MIME"text/plain", ex::SwizzleArray{dims}) where {dims}

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -704,4 +704,20 @@ using CIndices
         @finch (output .= 0; for i=_, j=_ output[] += A_hash[j,i] * B_hash[follow(j), i] end)
     end
 
+    let
+        A = zeros(2, 3, 3)
+        A[1, :, :] = [1 2 3; 4 5 6; 7 8 9]
+        A[2, :, :] = [1 1 1; 2 2 2; 3 3 3]
+        perm = (2, 3, 1)
+        A_t = permutedims(A, perm)
+
+        A_tns = Tensor(Dense(Dense(Dense(Element(0.0)))), A)
+        A_sw = swizzle(A_tns, perm...)
+
+        actual = broadcast(.*, A_t, A_t)
+        expected = broadcast(.*, A_sw, A_sw)
+
+        @test actual == expected
+    end
+
 end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -718,6 +718,10 @@ using CIndices
         expected = broadcast(.*, A_sw, A_sw)
 
         @test actual == expected
+
+        copyto!(A, A_sw)
+
+        @test A == A_t
     end
 
 end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -718,10 +718,11 @@ using CIndices
         expected = broadcast(.*, A_sw, A_sw)
 
         @test actual == expected
+        
+        B = zeros(size(A_sw)...)
+        copyto!(B, A_sw)
 
-        copyto!(zeros(size(A_sw)...), A_sw)
-
-        @test A == A_t
+        @test B == A_t
     end
 
 end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -719,7 +719,7 @@ using CIndices
 
         @test actual == expected
 
-        copyto!(A, A_sw)
+        copyto!(zeros(size(A_sw)...), A_sw)
 
         @test A == A_t
     end


### PR DESCRIPTION
Hi @willow-ahrens,

In the eager mode, I think there's an issue with `broadcast(fn, ::SwizzleArray, ::SwizzleArray)`. It complained about missing functions, but with them in place it fails when performing `copyto!`.

The `test/test_issues.jl` change reproduces the issue. 