### PR TITLE
Support `tensordot` and `reduce` for `SwizzleArray`

### DIFF
--- a/src/interface/eager.jl
+++ b/src/interface/eager.jl
@@ -31,9 +31,12 @@ function Base.copy(bc::Broadcasted{FinchStyle{N}}) where {N}
 end
 
 function Base.reduce(op, src::Tensor; kw...)
-    bc = broadcasted(identity, src)
     reduce(op, broadcasted(identity, src); kw...)
 end
+function Base.reduce(op, src::SwizzleArray; kw...)
+    reduce(op, broadcasted(identity, src); kw...)
+end
+
 function Base.mapreduce(f, op, src::Tensor, args::Union{Tensor, Base.AbstractArrayOrBroadcasted, Number}...; kw...)
     reduce(op, broadcasted(f, src, args...); kw...)
 end
@@ -54,6 +57,9 @@ function Base.reduce(op::Function, bc::Broadcasted{FinchStyle{N}}; dims=:, init 
 end
 
 function tensordot(A::Tensor, B::Tensor, idxs; kw...)
+    compute(tensordot(lazy(A), lazy(B), idxs; kw...))
+end
+function tensordot(A::SwizzleArray, B::SwizzleArray, idxs; kw...)
     compute(tensordot(lazy(A), lazy(B), idxs; kw...))
 end
 
@@ -92,7 +98,7 @@ Base.:-(x::Tensor, y::Tensor) = map(-, x, y)
 Base.:/(x::Tensor, y::Number) = map(/, x, y)
 Base.:/(x::Number, y::Tensor) = map(\, y, x)
 
-const FiberOrBroadcast = Union{<:Tensor, <:Broadcasted{FinchStyle{N}} where N}
+const FiberOrBroadcast = Union{<:Tensor, <:SwizzleArray, <:Broadcasted{FinchStyle{N}} where N}
 
 Base.sum(arr::FiberOrBroadcast; kwargs...) = reduce(+, arr; kwargs...)
 Base.prod(arr::FiberOrBroadcast; kwargs...) = reduce(*, arr; kwargs...)

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -725,4 +725,18 @@ using CIndices
         @test B == A_t
     end
 
+    #https://github.com/willow-ahrens/Finch.jl/issues/474
+    let
+        A = [1 2 3; 4 5 6; 7 8 9]
+        A_t = permutedims(A, (2, 1))
+        A_tns = Tensor(Dense(Dense(Element(0.0))), A)
+        A_sw = swizzle(A_tns, 2, 1)
+
+        @test prod(A_t; dims=2)[:, 1] == prod(A_sw; dims=2)
+        @test prod(A_t; dims=1)[1, :] == prod(A_sw; dims=1)
+        @test prod(A_t) == prod(A_sw)
+
+        @test tensordot(A_sw, A_sw, (2, 1)) == transpose(A * A)
+    end
+
 end


### PR DESCRIPTION
Issue #474 

Hi @willow-ahrens,

This PR contains support for `tensordot` and `reduce` operations for `SwizzleArrays`.

Should `FiberOrBroadcast` be renamed to also indicate that is considers `SwizzleArrays`?