### PR TITLE
fix NPZ reader for local paths

### DIFF
--- a/ext/NPZExt.jl
+++ b/ext/NPZExt.jl
@@ -9,7 +9,7 @@ isdefined(Base, :get_extension) ? (using NPZ) : (using ..NPZ)
 
 function Base.getindex(g::NPYPath, key::AbstractString)
     path = joinpath(g.dirname, key)
-    if isfile(key, "$path.npy")
+    if isfile("$path.npy")
         npzread("$path.npy")
     else
         NPYPath(path)

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -3,6 +3,18 @@ using SparseArrays
 @testset "issues" begin
     @info "Testing Github Issues"
 
+    #https://github.com/willow-ahrens/Finch.jl/issues/500
+    let
+        using NPZ
+        f = mktempdir("finch-issue-500")
+        cd(f) do
+            A = Tensor(Dense(Element(0.0)), rand(4))
+            fwrite("test.bspnpy", A)
+            B = fread("test.bspnpy")
+            @test A == B
+        end
+    end
+
     #https://github.com/willow-ahrens/Finch.jl/issues/358
     let
         A = Tensor(Dense(SparseList(Element(0))), [


### PR DESCRIPTION
Somehow isfile was getting called with two arguments, and this failed for local paths. I don't think isfile is meant to take two arguments.