### PR TITLE
CI: Add `finch-tensor` tests job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,4 +121,4 @@ jobs:
       - name: Run finch-tensor tests
         run: |
           cd finch-tensor
-          FINCH_REPO_PATH=${GITHUB_WORKSPACE} poetry run pytest tests/
+          FINCH_REPO_PATH="${GITHUB_WORKSPACE}" poetry run pytest tests/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,3 +89,36 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           BINDER_CACHE: true
           PUBLIC_REGISTRY_CHECK: true
+
+  finch-tensor-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Finch.jl
+        uses: actions/checkout@v4
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - name: Build Finch.jl package
+        uses: julia-actions/julia-buildpkg@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Checkout finch-tensor
+        uses: actions/checkout@v4
+        with:
+          repository: willow-ahrens/finch-tensor
+          ref: 'main'
+          path: 'finch-tensor'
+      - name: Install package
+        run: |
+          cd finch-tensor
+          poetry install --with test
+      - name: Run finch-tensor tests
+        run: |
+          cd finch-tensor
+          FINCH_REPO_PATH=${GITHUB_WORKSPACE} poetry run pytest tests/

--- a/docs/src/CONTRIBUTING.md
+++ b/docs/src/CONTRIBUTING.md
@@ -78,6 +78,21 @@ test suites by specifying them as positional arguments, e.g.
 
 This information is summarized with `./test/runtests.jl --help`
 
+### Python test suite
+
+[finch-tensor](https://github.com/willow-ahrens/finch-tensor) contains
+a separate Array API compatible test suite written in Python. It requires
+Python 3.10 or later and Poetry installed.
+
+It can be run with:
+
+```sh
+git clone https://github.com/willow-ahrens/finch-tensor.git
+cd finch-tensor
+poetry install --with test
+FINCH_REPO_PATH=<PATH_TO_FINCH_REPO> poetry run pytest tests/
+```
+
 ## Benchmarking
 
 The Finch test suite includes a benchmarking script that measures Finch


### PR DESCRIPTION
Addresses: https://github.com/willow-ahrens/Finch.jl/issues/539

Hi @willow-ahrens @hameerabbasi,

This PR adds CI job that runs downstream `finch-tensor` tests against new changes in Finch.jl to catch regressions.