### PR TITLE
Wma/fix565

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Willow Ahrens"]
 name = "Finch"
 uuid = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
-version = "0.6.29"
+version = "0.6.30"
 
 [compat]
 AbstractTrees = "0.3.4, 0.4"

--- a/docs/src/guides/interoperability.md
+++ b/docs/src/guides/interoperability.md
@@ -30,26 +30,31 @@ julia> v = Vector([1, 0, 2, 3])
  0
  2
  3
+
 julia> obov = PlusOneVector(v)
-4-element PlusOneVector{Int64}:
+4-element PlusOneVector{Int64, Vector{Int64}}:
  2
  1
  3
  4
+
 julia> obov[1] += 8
 10
+
 julia> obov
-4-element PlusOneVector{Int64}:
+4-element PlusOneVector{Int64, Vector{Int64}}:
  10
   1
   3
   4
+
 julia> obov.data
 4-element Vector{Int64}:
  9
  0
  2
  3
+
 ```
 
 ### `CIndex`

--- a/src/util/vectors.jl
+++ b/src/util/vectors.jl
@@ -4,8 +4,6 @@ struct PlusOneVector{T, A <: AbstractVector{T}} <: AbstractVector{T}
     data::A
 end
 
-PlusOneVector(data::AbstractVector{T}) where {T} = PlusOneVector{T, typeof(data)}(data)
-
 @propagate_inbounds function Base.getindex(vec::PlusOneVector{T},
                                            index::Int) where {T}
     return vec.data[index] + 0x01

--- a/src/util/vectors.jl
+++ b/src/util/vectors.jl
@@ -1,7 +1,7 @@
 using Base: @propagate_inbounds
 
-struct PlusOneVector{T} <: AbstractVector{T}
-    data::AbstractVector{T}
+struct PlusOneVector{T, A <: AbstractVector{T}} <: AbstractVector{T}
+    data::A
 end
 
 @propagate_inbounds function Base.getindex(vec::PlusOneVector{T},

--- a/src/util/vectors.jl
+++ b/src/util/vectors.jl
@@ -4,6 +4,8 @@ struct PlusOneVector{T, A <: AbstractVector{T}} <: AbstractVector{T}
     data::A
 end
 
+PlusOneVector(data::AbstractVector{T}) where {T} = PlusOneVector{T, typeof(data)}(data)
+
 @propagate_inbounds function Base.getindex(vec::PlusOneVector{T},
                                            index::Int) where {T}
     return vec.data[index] + 0x01
@@ -36,11 +38,11 @@ function moveto(vec::PlusOneVector{T}, device) where {T}
     return PlusOneVector{T}(data)
 end
 
-struct MinusEpsVector{T, S} <: AbstractVector{T}
-    data::AbstractVector{S}
+struct MinusEpsVector{T, S, A <: AbstractVector{S}} <: AbstractVector{T}
+    data::A
 end
 
-MinusEpsVector(data::AbstractVector{T}) where {T} = MinusEpsVector{Limit{T}, T}(data)
+MinusEpsVector(data::AbstractVector{T}) where {T} = MinusEpsVector{Limit{T}, T, typeof(data)}(data)
 
 @propagate_inbounds function Base.getindex(vec::MinusEpsVector{T},
                                            index::Int) where {T}
@@ -80,11 +82,11 @@ function moveto(vec::MinusEpsVector{T}, device) where {T}
     return MinusEpsVector{T}(data)
 end
 
-struct PlusEpsVector{T, S} <: AbstractVector{T}
-    data::AbstractVector{S}
+struct PlusEpsVector{T, S, A <:AbstractVector{S}} <: AbstractVector{T}
+    data::A
 end
 
-PlusEpsVector(data::AbstractVector{T}) where {T} = PlusEpsVector{Limit{T}, T}(data)
+PlusEpsVector(data::AbstractVector{T}) where {T} = PlusEpsVector{Limit{T}, T, typeof(data)}(data)
 
 @propagate_inbounds function Base.getindex(vec::PlusEpsVector{T},
                                            index::Int) where {T}


### PR DESCRIPTION
fixes #565
```

  Benchmark Report for /Users/willow/Projects/Finch.jl
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  Job Properties
  ==============

    •  Time of benchmarks:
       • Target: 21 May 2024 - 16:32
       • Baseline: 21 May 2024 - 16:34

    •  Package commits:
       • Target: 42219b
       • Baseline: ee5908

    •  Julia commits:
       • Target: 0b4590
       • Baseline: 0b4590

    •  Julia command flags:
       • Target: None
       • Baseline: None

    •  Environment variables:
       • Target: JULIA_NUM_THREADS => 1
       • Baseline: JULIA_NUM_THREADS => 1

  Results
  =======

  A ratio greater than 1.0 denotes a possible regression (marked with ❌), while a ratio less than 1.0 denotes a possible improvement (marked with ✅). Only significant results - results that indicate possible regressions or improvements - are
  shown below (thus, an empty table means that all benchmark results remained invariant between builds).

                                              ID   time ratio memory ratio
  –––––––––––––––––––––––––––––––––––––––––––––– –––––––––––– ––––––––––––
  ["graphs", "bellmanford", "Newman/netscience"] 0.92 (5%) ✅    1.00 (1%)
    ["graphs", "bellmanford", "SNAP/roadNet-CA"] 1.27 (5%) ❌    1.00 (1%)
     ["high-level", "einsum_spmv_call_overhead"] 0.90 (5%) ✅    1.00 (1%)
    ["indices", "SpMV_p1", "SNAP/soc-Epinions1"] 0.01 (5%) ✅ 0.01 (1%) ✅
```