### PR TITLE
SpMM Data Structures Bitmap implementation

### DIFF
--- a/src/custom-imp.jl
+++ b/src/custom-imp.jl
@@ -1,0 +1,453 @@
+using Pkg
+Pkg.add("StatsBase")
+Pkg.add("BenchmarkTools")
+Pkg.add("SparseArrays")
+Pkg.add("Finch")
+Pkg.add("JSON3")
+Pkg.add("HDF5")
+
+using StatsBase
+using BenchmarkTools
+using SparseArrays
+using Finch
+using JSON3
+using HDF5
+
+
+function custom_coo_setup(M)
+    # define the exact type of u to remove "Any"
+    u = Vector{Tuple{Int, Int, Float64}}()
+    i_d, j_d = size(M)
+
+    for i in 1:i_d
+        for j in 1:j_d
+            if M[i, j] != 0
+                push!(u, (i, j, M[i, j]))
+            end
+        end
+    end
+
+    return u
+end
+
+function custom_coo_mul(M, X)
+    # use @inbound to avoid bound check when accessing indices (y[i, d], X[j, d])
+    @inbounds begin
+        # @fastmath to allow floating point optimizations that are correct for real numbers
+        @fastmath begin
+            y = zeros(size(X, 1), size(X, 2))
+            s = size(X, 2)
+            for (i, j, v) in M
+                for d in 1:s
+                    y[i, d] += v * X[j, d]
+                end
+            end
+        end
+    end
+    return y
+end
+
+
+function custom_coo(M, X, sol)
+    m_coo = custom_coo_setup(M)
+
+    bench_results = @benchmark custom_coo_mul($m_coo, $X)
+    temp = custom_coo_mul(m_coo, X)
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return (minimum(bench_results.times))
+    else
+        return -1
+    end
+end
+
+
+function custom_coo_sep_mul(I, J, V, X)
+    @inbounds begin
+        @fastmath begin
+            y = zeros(size(X, 1), size(X, 2))
+            size_m = size(I, 1)
+            s = size(X, 2)
+            for p in 1:size_m
+                i_p = I[p]
+                j_p = J[p]
+                v_p = V[p]
+
+                # add potential SIMD
+                @simd for d in 1:s
+                    y[i_p, d] += v_p * X[j_p, d]
+                end
+            end
+        end
+    end
+    return y
+end
+
+
+function unzip(A)
+    return map(x->getfield.(A, x), fieldnames(eltype(A)))
+end
+
+
+function custom_coo_sep(M, X, sol)
+    m_coo = custom_coo_setup(M)
+    I, J, V = unzip(m_coo)
+
+    bench_results = @benchmark custom_coo_sep_mul($I, $J, $V, $X)
+    temp = custom_coo_sep_mul(I, J, V, X)
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return (minimum(bench_results.times))
+    else
+        return -1
+    end
+end
+
+
+function custom_csc_mul(A::SparseMatrixCSC, X)
+    @inbounds begin
+        @fastmath begin
+            # work with permuted matrix for row-major
+            X_t = permutedims(X)
+            ptr = A.colptr
+            idx = A.rowval
+            val = A.nzval
+
+            m, n = size(A)
+            n, d = size(X)
+
+            Y_t = zeros(d, m)
+
+            for j in 1:n
+                st = ptr[j]
+                ed = ptr[j+1] - 1
+                for p in st:ed
+                    i = idx[p]
+                    v = val[p]
+                    for k in 1:d
+                        Y_t[k, i] += v * X_t[k, j]
+                    end
+                end
+            end
+        end
+    end
+    return permutedims(Y_t)
+end
+
+
+function custom_csc(M, X, sol)
+    m_csc = sparse(M)
+
+    bench_results = @benchmark custom_csc_mul($m_csc, $X)
+    temp = custom_csc_mul(m_csc, X)
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return (minimum(bench_results.times))
+    else
+        return -1
+    end
+end
+
+
+function bytemap(M)
+    i_d = size(M, 1)
+    j_d = size(M, 2)
+    B = zeros(Int8, i_d, j_d)
+    val = Vector{Float64}()
+    for i in 1:i_d
+        for j in 1:j_d
+            if M[i, j] != 0.0
+                B[i, j] = 1
+                push!(val, M[i, j])
+            else
+                B[i, j] = 0
+            end
+        end
+    end
+    return B, val 
+end
+
+
+function custom_bytemap_mul(B, val, X)
+    i_d = size(B, 1)
+    j_d = size(B, 2)
+    k_d = size(X, 2)
+    Y_t = zeros(k_d, i_d)
+    X_t = transpose(X)
+
+    cnt = 1
+    @inbounds begin
+        @fastmath begin
+            for i in 1:i_d
+                for j in 1:j_d
+                    if B[i, j] == 1
+                        v = val[cnt]
+                        for k in 1:k_d
+                            Y_t[k, i] += v * X_t[k, j]
+                        end
+                        cnt += 1
+                    end
+                end
+            end
+        end
+    end
+
+    return transpose(Y_t)
+end
+
+
+function custom_bytemap(M, X, sol)
+    B, val = bytemap(M)
+
+    bench_results = @benchmark custom_bytemap_mul($B, $val, $X)
+    temp = custom_bytemap_mul(B, val, X)
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return (minimum(bench_results.times))
+    else
+        return -1
+    end
+end
+
+
+function bitmap(M)
+    i_d = size(M, 1)
+    j_d = size(M, 2)
+
+    b_j = ceil(Int64, j_d / 64)
+
+    B = zeros(UInt64, i_d, b_j)
+    val = Vector{Float64}()
+    for i in 1:i_d
+        for j in 1:j_d
+            if M[i, j] != 0.0
+                push!(val, M[i, j])
+                B[i, div(j - 1, 64) + 1] |= 1 << (63 - ((j - 1) % 64))
+            end
+        end
+    end
+    return B, val 
+end
+
+
+function custom_bitmap_mul(B, val, X)
+    i_dim = size(B, 1)
+    j_wdim = size(B, 2)
+    k_dim = size(X, 2)
+    Y_t = zeros(k_dim, i_dim)
+    X_t = transpose(X)
+
+    cnt = 1
+    @inbounds begin
+        @fastmath begin
+            for i in 1:i_dim
+                for j_w in 1:j_wdim
+                    word = B[i, j_w]
+                    if word == 0
+                        continue
+                    end
+
+                    bit_id = 0
+                    while word != 0
+                        bit_id += 1
+                        bit_msk = 1 << (64 - bit_id)
+                        if word & bit_msk == 0
+                            continue
+                        else
+                            word &= ~bit_msk
+                            v = val[cnt]
+                            j = (j_w - 1) * 64 + bit_id
+                            for k in 1:k_dim
+                                Y_t[k, i] += v * X_t[k, j]
+                            end
+                            cnt += 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return transpose(Y_t)
+end
+
+
+function custom_bitmap(M, X, sol)
+    B, val = bitmap(M)
+
+    bench_results = @benchmark custom_bitmap_mul($B, $val, $X)
+    temp = custom_bitmap_mul(B, val, X)
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return (minimum(bench_results.times))
+    else
+        return -1
+    end
+end
+
+
+function main()
+    N = 250
+    eps = 1e-6
+
+    indices = exp10.(range(log10(eps), log10(0.5), length=N))
+
+    X = fread("ben/x.bsp.h5")
+
+
+    # # custom coo
+    # pairs_coo = []
+    # println("For custom coo multiplication:")
+    # k = -1
+    # for i in indices
+    #     # reduce number of runs
+    #     k += 1
+    #     if k % 10 != 0
+    #         continue
+    #     end
+
+    #     M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+    #     X_dense = Array(X)
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local custom_coo_val = custom_coo(M_dense, X_dense, sol)
+    #     if custom_coo_val != -1
+    #         println("\t\tTime: \t", custom_coo_val, "ns")
+    #         push!(pairs_coo, (i, custom_coo_val))
+    #     else
+    #         println("\t\tcustom COO: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/1005/custom-coo-opt.json", "w") do f
+    #     JSON3.write(f, pairs_coo)
+    # end
+
+
+    # # custom coo with decoupled tuples
+    # pairs_coo_sep = []
+    # println("For custom coo with decoupled tuples multiplication:")
+    # k = -1
+    # for i in indices
+    #     # reduce number of runs
+    #     k += 1
+    #     if k % 10 != 0
+    #         continue
+    #     end
+
+    #     M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+    #     X_dense = Array(X)
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local custom_coo_sep_val = custom_coo_sep(M_dense, X_dense, sol)
+    #     if custom_coo_sep_val != -1
+    #         println("\t\tTime: \t", custom_coo_sep_val, "ns")
+    #         push!(pairs_coo_sep, (i, custom_coo_sep_val))
+    #     else
+    #         println("\t\tcustom COO sep: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/1005/custom-coo-sep.json", "w") do f
+    #     JSON3.write(f, pairs_coo_sep)
+    # end
+
+
+    # # custom csc
+    # pairs_csc = []
+    # println("For custom csc multiplication:")
+    # # k = -1
+    # for i in indices
+    #     # # reduce number of runs
+    #     # k += 1
+    #     # if k % 10 != 0
+    #     #     continue
+    #     # end
+
+    #     M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+    #     X_dense = Array(X)
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local custom_csc_val = custom_csc(M_dense, X_dense, sol)
+    #     if custom_csc_val != -1
+    #         println("\t\tTime: \t", custom_csc_val, "ns")
+    #         push!(pairs_csc, (i, custom_csc_val))
+    #     else
+    #         println("\t\tcustom CSC: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/1005/custom-csc.json", "w") do f
+    #     JSON3.write(f, pairs_csc)
+    # end
+
+
+    # custom bytemap
+    pairs_bm = []
+    println("For custom bytemap multiplication:")
+    k = -1
+    for i in indices
+        # reduce number of runs
+        k += 1
+        if k % 10 != 0
+            continue
+        end
+
+        M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+        X_dense = Array(X)
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+
+        local custom_bm_val = custom_bytemap(M_dense, X_dense, sol)
+        if custom_bm_val != -1
+            println("\t\tTime: \t", custom_bm_val, "ns")
+            push!(pairs_bm, (i, custom_bm_val))
+        else
+            println("\t\tcustom bytemap: matmul resulted in wrong answer.")
+        end
+    end
+
+    open("res/1010/custom-bytem.json", "w") do f
+        JSON3.write(f, pairs_bm)
+    end
+
+
+    # custom bitmap
+    pairs_bitm = []
+    println("For custom bitmap multiplication:")
+    k = -1
+    for i in indices
+        # reduce number of runs
+        k += 1
+        if k % 10 != 0
+            continue
+        end
+
+        M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+        X_dense = Array(X)
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+
+        local custom_bm_val = custom_bytemap(M_dense, X_dense, sol)
+        if custom_bm_val != -1
+            println("\t\tTime: \t", custom_bm_val, "ns")
+            push!(pairs_bm, (i, custom_bm_val))
+        else
+            println("\t\tcustom bitmap: matmul resulted in wrong answer.")
+        end
+    end
+
+    open("res/1019/custom-bitm.json", "w") do f
+        JSON3.write(f, pairs_bitm)
+    end    
+end
+
+main()

--- a/src/spmm-fin-mac.jl
+++ b/src/spmm-fin-mac.jl
@@ -1,0 +1,477 @@
+using Pkg
+Pkg.add("StatsBase")
+Pkg.add("BenchmarkTools")
+Pkg.add("SparseArrays")
+Pkg.add("SuiteSparseGraphBLAS")
+Pkg.add("Finch")
+Pkg.add("JSON3")
+Pkg.add("HDF5")
+
+using StatsBase
+using BenchmarkTools
+using SparseArrays
+using SuiteSparseGraphBLAS
+using Finch
+using JSON3
+using HDF5
+
+
+const SIZE = 8192
+const SKINNY = 100
+
+
+
+
+
+function fin_csc(M, X, sol)
+    m_ten = Finch.Tensor(CSCFormat(), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(CSCFormat(), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+function fin_csf(M, X, sol)
+    m_ten = Finch.Tensor(CSFFormat(2), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(CSFFormat(2), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+function fin_dcsc(M, X, sol)
+    m_ten = Finch.Tensor(DCSCFormat(), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(DCSCFormat(), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+function fin_dcsf(M, X, sol)
+    m_ten = Finch.Tensor(DCSFFormat(2), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(DCSFFormat(2), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+function fin_coo(M, X, sol)
+    m_ten = Finch.Tensor(COOFormat(2), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(COOFormat(2), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+function fin_hash(M, X, sol)
+    m_ten = Finch.Tensor(HashFormat(2), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(HashFormat(2), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+function fin_bytemap(M, X, sol)
+    m_ten = Finch.Tensor(ByteMapFormat(2), M)
+    x_tra = transpose(X)
+    x_ten = Finch.Tensor(ByteMapFormat(2), x_tra)
+    temp_tra = zeros(size(X, 2), size(M, 1))
+
+    t = @benchmark begin 
+        $temp_tra .= 0.0
+        @finch begin
+            for j = _
+                for i = _
+                    for k = _
+                        $temp_tra[k, i] += $m_ten[i, j] * $x_ten[k, j]
+                    end
+                end
+            end
+        end
+    end
+
+    @finch begin
+        temp_tra .= 0.0
+        for j = _
+            for i = _
+                for k = _
+                    temp_tra[k, i] += m_ten[i, j] * x_ten[k, j]
+                end
+            end
+        end
+    end
+
+    temp = transpose(temp_tra)
+
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return minimum(t.times)
+    else
+        return -1
+    end
+end
+
+
+function main()
+    N = 250
+    eps = 1e-6
+
+    indices = exp10.(range(log10(eps), log10(0.5), length=N))
+
+    X = Array(fread("ben/x.bsp.h5"))
+
+
+    # # finch csc 
+    # pairs_fin_csc = []
+    # println("For finch csc multiplication:")
+    # for i in indices
+    #     M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local fin_csc_val = fin_csc(M_dense, X, sol)
+    #     if fin_csc_val != -1
+    #         println("\t\tTime: \t", fin_csc_val, "ns")
+    #         push!(pairs_fin_csc, (i, fin_csc_val))
+    #     else
+    #         println("\t\tfinch CSC: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/1019/finch-csc.json", "w") do f
+    #     JSON3.write(f, pairs_fin_csc)
+    # end
+
+
+    # # finch csf
+    # pairs_fin_csf = []
+    # println("For finch csf multiplication:")
+    # for i in indices
+    #             M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local fin_csf_val = fin_csf(M_dense, X, sol)
+    #     if fin_csf_val != -1
+    #         println("\t\tTime: \t", fin_csf_val, "ns")
+    #         push!(pairs_fin_csf, (i, fin_csf_val))
+    #     else
+    #         println("\t\tfinch CSF: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/1019/finch-csf.json", "w") do f
+    #     JSON3.write(f, pairs_fin_csf)
+    # end
+
+
+    # # finch dcsc
+    # pairs_fin_dcsc = []
+    # println("For finch dcsc multiplication:")
+    # for i in indices
+    #             M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local fin_dcsc_val = fin_dcsc(M_dense, X, sol)
+    #     if fin_dcsc_val != -1
+    #         println("\t\tTime: \t", fin_dcsc_val, "ns")
+    #         push!(pairs_fin_dcsc, (i, fin_dcsc_val))
+    #     else
+    #         println("\t\tfinch DCSC: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/1019/finch-dcsc.json", "w") do f
+    #     JSON3.write(f, pairs_fin_dcsc)
+    # end
+
+
+    # finch dcsf
+    pairs_fin_dcsf = []
+    println("For finch dcsf multiplication:")
+    for i in indices
+                M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+
+        local fin_dcsf_val = fin_dcsf(M_dense, X, sol)
+        if fin_dcsf_val != -1
+            println("\tfinch DCSF: \t\t", fin_dcsf_val, "ns")
+            push!(pairs_fin_dcsf, (i, fin_dcsf_val))
+        else
+            println("\tfinch DCSF: matmul resulted in wrong answer.")
+        end
+    end
+
+    open("res/1019/finch-dcsf.json", "w") do f
+        JSON3.write(f, pairs_fin_dcsf)
+    end
+
+
+    # finch coo
+    pairs_fin_coo = []
+    println("For finch coo multiplication:")
+    for i in indices
+                M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+
+        local fin_coo_val = fin_coo(M_dense, X, sol)
+        if fin_coo_val != -1
+            println("\tfinch COO: \t\t", fin_coo_val, "ns")
+            push!(pairs_fin_coo, (i, fin_coo_val))
+        else
+            println("\tfinch COO: matmul resulted in wrong answer.")
+        end
+    end
+
+    open("res/1019/finch-coo.json", "w") do f
+        JSON3.write(f, pairs_fin_coo)
+    end
+
+
+    # finch hash
+    pairs_fin_hash = []
+    println("For finch hash multiplication:")
+    for i in indices
+                M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+
+        local fin_hash_val = fin_hash(M_dense, X, sol)
+        if fin_hash_val != -1
+            println("\tfinch Hash: \t\t", fin_hash_val, "ns")
+            push!(pairs_fin_hash, (i, fin_hash_val))
+        else
+            println("\tfinch Hash: matmul resulted in wrong answer.")
+        end
+    end
+
+    open("res/1019/finch-hash.json", "w") do f
+        JSON3.write(f, pairs_fin_hash)
+    end
+
+
+    # finch bytemap
+    pairs_fin_bytemap = []
+    println("For finch bytemap multiplication:")
+    for i in indices
+                M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+
+        local fin_bm_val = fin_bytemap(M_dense, X, sol)
+        if fin_bm_val != -1
+            println("\tfinch Bytemap: \t\t", fin_bm_val, "ns")
+            push!(pairs_fin_bytemap, (i, fin_bm_val))
+        else
+            println("\tfinch Bytemap: matmul resulted in wrong answer.")
+        end
+    end
+
+    open("res/1019/finch-bm.json", "w") do f
+        JSON3.write(f, pairs_fin_bytemap)
+    end
+end
+
+main()

--- a/src/spmm-refine.jl
+++ b/src/spmm-refine.jl
@@ -1,0 +1,97 @@
+using Pkg
+Pkg.add("StatsBase")
+Pkg.add("BenchmarkTools")
+Pkg.add("SparseArrays")
+Pkg.add("Finch")
+Pkg.add("JSON3")
+Pkg.add("HDF5")
+Pkg.add("LinearAlgebra")
+
+using StatsBase
+using BenchmarkTools
+using SparseArrays
+using Finch
+using JSON3
+using HDF5
+using LinearAlgebra
+
+
+function sa_csc(M, X, sol)
+    m_sparse = sparse(M)
+
+    bench_results = @benchmark $m_sparse * $X
+    temp = m_sparse * X
+    if isapprox(temp, sol; rtol=1e-8, atol=1e-12)
+        return (minimum(bench_results.times))
+    else
+        return -1
+    end
+end
+
+
+function main()
+    N = 250
+    eps = 1e-6
+
+    indices = exp10.(range(log10(eps), log10(0.5), length=N))
+
+    X = fread("ben/x.bsp.h5")
+
+    # dense 
+    pairs_dense = []
+    println("For dense matrix multiplication:")
+    for i in indices
+        M_dense = fread(string("ben/m", i, ".bsp.h5"))
+        X_dense = Array(X)
+        sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+
+        println("\tDensity: ", i)
+        M_dense = Array(M_dense)
+        sol_calc = M_dense * X_dense
+
+        num_t = LinearAlgebra.BLAS.get_num_threads()
+        LinearAlgebra.BLAS.set_num_threads(1)
+
+        bench_results = @benchmark $M_dense * $X_dense
+
+        LinearAlgebra.BLAS.set_num_threads(num_t)
+
+        if isapprox(sol_calc, sol; rtol=1e-8, atol=1e-12)
+            println("\t\tTime: \t", minimum(bench_results.times), "ns")
+            push!(pairs_dense, (i, minimum(bench_results.times)))
+        else
+            println("\t\tWrong result.")
+        end
+    end
+
+    open("res/1019/dense.json", "w") do f
+        JSON3.write(f, pairs_dense)
+    end
+
+
+    # # sparse arrays
+    # pairs_sa_csc = []
+    # println("For SparseArrays CSC multiplication:")
+    # for i in indices
+    #     M_dense = fread(string("ben/m", i, ".bsp.h5"))
+    #     sol = Array(fread(string("ben/sol", i, ".bsp.h5")))
+    #     X_dense = Array(X)
+
+    #     println("\tDensity: ", i)
+    #     M_dense = Array(M_dense)
+
+    #     local sa_csc_val = sa_csc(M_dense, X_dense, sol)
+    #     if sa_csc_val != -1
+    #         println("\t\tTime: \t", sa_csc_val, "ns")
+    #         push!(pairs_sa_csc, (i, sa_csc_val))
+    #     else
+    #         println("\t\tSparseArray CSC: matmul resulted in wrong answer.")
+    #     end
+    # end
+
+    # open("res/0929/sparse-arrays-csc.json", "w") do f
+    #     JSON3.write(f, pairs_sa_csc)
+    # end
+end
+
+main()


### PR DESCRIPTION
PR made solely for the purpose of sharing code for the meeting. Unless I make a crucial update, the code I will bring to the meeting will mostly be the same as it is here.

spmm-refine.jl and spmm-fin-mac.jl only had minor changes where I adjusted the way of measuring dense mat mul (using only a single thread) and finch tensors (utilizing column major), but I thought I would add the files just for your reference.

custom-imp.jl contains the bytemap implementation with slight modification after the last meeting and a new bitmap mat mul. The runtimes do improve relatively to other sparse data types as the density increases, but it still performs worse in general.