### PR TITLE
Support Matrix Market symmetry and binsparse fixtures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Finch"
 uuid = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
-authors = ["Willow Ahrens"]
 version = "1.2.12"
+authors = ["Willow Ahrens"]
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -18,6 +18,7 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 RewriteTools = "5969e224-3634-4c61-9f66-721b69e98b8a"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SyntaxInterface = "b33eeca9-aacb-4496-a840-e75f1646a4fb"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
@@ -26,12 +27,13 @@ UnsafeAtomics = "013be700-e6cd-48c3-b4a1-df204f14c38f"
 
 [weakdeps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+MatrixMarket = "4d4711f2-db25-561a-b6b3-d35e7d4047d3"
 NPZ = "15e1cf62-19b3-5cfa-8e77-841668bca605"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TensorMarket = "8b7d4fe7-0b45-4d0d-9dd8-5cc9b23b4b77"
 
 [extensions]
 HDF5Ext = "HDF5"
+MatrixMarketExt = "MatrixMarket"
 NPZExt = "NPZ"
 SparseArraysExt = "SparseArrays"
 TensorMarketExt = "TensorMarket"
@@ -46,6 +48,7 @@ Distributions = "0.25"
 HDF5 = "0.17"
 IterTools = "1.10.0"
 JSON = "1.2"
+MatrixMarket = "0.5.2"
 NPZ = "0.4"
 PrecompileTools = "1"
 Preferences = "v1.4.3"

--- a/bin/bsp2mtx
+++ b/bin/bsp2mtx
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+
+exec julia --project="$repo_root/test" "$script_dir/finch_fileio_cli.jl" bsp2mtx "$@"

--- a/bin/check_equivalence
+++ b/bin/check_equivalence
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+
+exec julia --project="$repo_root/test" "$script_dir/finch_fileio_cli.jl" check_equivalence "$@"

--- a/bin/finch_fileio_cli.jl
+++ b/bin/finch_fileio_cli.jl
@@ -1,0 +1,111 @@
+#!/usr/bin/env julia
+
+using Finch
+using HDF5
+using MatrixMarket
+using SparseArrays
+
+function usage(io::IO = stderr)
+    println(io, "usage:")
+    println(io, "  finch_fileio_cli.jl mtx2bsp INPUT.mtx OUTPUT.bsp.h5[:DATASET]")
+    println(io, "  finch_fileio_cli.jl bsp2mtx INPUT.bsp.h5[:DATASET] OUTPUT.mtx")
+    println(io, "  finch_fileio_cli.jl check_equivalence FILE1 FILE2")
+    return 1
+end
+
+function split_path_and_dataset(value::AbstractString)
+    if !occursin(':', value)
+        return String(value), nothing
+    end
+
+    path, dataset = rsplit(value, ':'; limit=2)
+    if endswith(path, ".h5") || endswith(path, ".hdf5")
+        return path, isempty(dataset) ? nothing : dataset
+    end
+
+    return String(value), nothing
+end
+
+function lookup_group(io::HDF5.File, dataset::AbstractString)
+    group = io
+    for part in split(dataset, '/')
+        isempty(part) && continue
+        group = group[part]
+    end
+    return group
+end
+
+function ensure_group(io::HDF5.File, dataset::AbstractString)
+    group = io
+    for part in split(dataset, '/')
+        isempty(part) && continue
+        group = haskey(group, part) ? group[part] : create_group(group, part)
+    end
+    return group
+end
+
+function read_tensor(path_with_dataset::AbstractString)
+    path, dataset = split_path_and_dataset(path_with_dataset)
+    if dataset === nothing
+        return Finch.fread(path)
+    end
+
+    if !(endswith(path, ".bsp.h5") || endswith(path, ".bsp.hdf5"))
+        throw(ArgumentError("dataset addressing is only supported for binsparse HDF5 files"))
+    end
+
+    h5open(path, "r") do io
+        Finch.bspread(lookup_group(io, dataset))
+    end
+end
+
+function write_tensor(path_with_dataset::AbstractString, tensor)
+    path, dataset = split_path_and_dataset(path_with_dataset)
+    if dataset === nothing
+        Finch.fwrite(path, tensor)
+        return path
+    end
+
+    if !(endswith(path, ".bsp.h5") || endswith(path, ".bsp.hdf5"))
+        throw(ArgumentError("dataset addressing is only supported for binsparse HDF5 files"))
+    end
+
+    h5open(path, "w") do io
+        Finch.bspwrite(ensure_group(io, dataset), tensor)
+    end
+    return path
+end
+
+function tensors_equivalent(left, right)
+    size(left) == size(right) || return false
+    if ndims(left) == 2 && ndims(right) == 2
+        return SparseMatrixCSC(left) == SparseMatrixCSC(right)
+    end
+    return left == right
+end
+
+function main(args)
+    length(args) == 3 || return usage()
+    command, arg1, arg2 = args
+
+    if command == "mtx2bsp"
+        write_tensor(arg2, Finch.fread(arg1))
+        return 0
+    elseif command == "bsp2mtx"
+        Finch.fwrite(arg2, read_tensor(arg1))
+        return 0
+    elseif command == "check_equivalence"
+        left = read_tensor(arg1)
+        right = read_tensor(arg2)
+        if tensors_equivalent(left, right)
+            println("OK")
+            return 0
+        end
+        println(stderr, "files are not equivalent")
+        return 1
+    else
+        return usage()
+    end
+end
+
+exit(main(ARGS))

--- a/bin/mtx2bsp
+++ b/bin/mtx2bsp
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+
+exec julia --project="$repo_root/test" "$script_dir/finch_fileio_cli.jl" mtx2bsp "$@"

--- a/ext/HDF5Ext.jl
+++ b/ext/HDF5Ext.jl
@@ -6,6 +6,8 @@ using Finch.DataStructures
 
 isdefined(Base, :get_extension) ? (using HDF5) : (using ..HDF5)
 
+const HDF5Node = Union{HDF5.File,HDF5.Group}
+
 function Finch.bspread_h5(fname::AbstractString)
     h5open(fname, "r") do io
         Finch.bspread(io)
@@ -19,9 +21,9 @@ function Finch.bspwrite_h5(fname::AbstractString, arr, attrs=OrderedDict())
     fname
 end
 
-Finch.bspread_header(f::HDF5.File) = JSON.parse(read(attributes(f)["binsparse"]))
-Finch.bspwrite_header(f::HDF5.File, str::String) = (attributes(f)["binsparse"] = str)
-Finch.bspread_vector(g::HDF5.File, key) = read(g[key])
-Finch.bspwrite_vector(g::HDF5.File, vec, key) = (g[key] = vec)
+Finch.bspread_header(f::HDF5Node) = JSON.parse(read(attributes(f)["binsparse"]))
+Finch.bspwrite_header(f::HDF5Node, str::String) = (attributes(f)["binsparse"] = str)
+Finch.bspread_vector(g::HDF5Node, key) = read(g[key])
+Finch.bspwrite_vector(g::HDF5Node, vec, key) = (g[key] = vec)
 
 end

--- a/ext/MatrixMarketExt.jl
+++ b/ext/MatrixMarketExt.jl
@@ -1,0 +1,16 @@
+module MatrixMarketExt
+
+using Finch
+using SparseArrays
+
+isdefined(Base, :get_extension) ? (using MatrixMarket) : (using ..MatrixMarket)
+
+function Finch.fmmread(filename::AbstractString)
+    Tensor(sparse(mmread(filename)))
+end
+
+function Finch.fmmwrite(filename::AbstractString, A)
+    mmwrite(filename, SparseMatrixCSC(A))
+end
+
+end

--- a/src/Finch.jl
+++ b/src/Finch.jl
@@ -17,6 +17,7 @@ using DataStructures
 using Statistics
 using JSON
 using Distributions: Binomial, Normal, Poisson
+using SparseArrays
 using TOML
 using UUIDs
 using Preferences
@@ -312,6 +313,9 @@ export galley_scheduler, GalleyOptimizer, AdaptiveExecutorCode, AdaptiveExecutor
             "../ext/SparseArraysExt.jl"
         )
         @require HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" include("../ext/HDF5Ext.jl")
+        @require MatrixMarket = "4d4711f2-db25-561a-b6b3-d35e7d4047d3" include(
+            "../ext/MatrixMarketExt.jl"
+        )
         @require TensorMarket = "8b7d4fe7-0b45-4d0d-9dd8-5cc9b23b4b77" include(
             "../ext/TensorMarketExt.jl"
         )

--- a/src/interface/fileio/binsparse.jl
+++ b/src/interface/fileio/binsparse.jl
@@ -59,7 +59,17 @@ function bspwrite_vector end
 function bspread_data(f, desc, key)
     t = desc["data_types"][key]
     if (m = match(r"^iso\[([^\[]*)\]$", t)) !== nothing
-        throw(ArgumentError("iso values not currently supported"))
+        inner_type = m.captures[1]
+        original = desc["data_types"][key]
+        desc["data_types"][key] = inner_type
+        data = bspread_data(f, desc, key)
+        desc["data_types"][key] = original
+
+        n = key == "values" ? Int(desc["number_of_stored_values"]) : length(data)
+        if n == 0
+            return similar(data, 0)
+        end
+        return fill(data[1], n)
     elseif (m = match(r"^complex\[([^\[]*)\]$", t)) !== nothing
         desc["data_types"][key] = m.captures[1]
         data = bspread_data(f, desc, key)
@@ -329,6 +339,11 @@ function bspread_header end
 function bspread(f)
     desc = bspread_header(f)["binsparse"]
     @assert desc["version"] == "$BINSPARSE_VERSION"
+
+    if get(desc, "format", nothing) == "COO" && length(desc["shape"]) == 2
+        return bspread_coo_matrix(f, desc)
+    end
+
     fmt = OrderedDict{Any,Any}(
         get(() -> bspread_tensor_lookup[desc["format"]], desc, "custom")
     )
@@ -343,10 +358,77 @@ function bspread(f)
     if !issorted(reverse(fmt["transpose"]))
         fbr = swizzle(fbr, reverse(fmt["transpose"] .+ 1)...)
     end
-    if haskey(desc, "structure")
-        throw(ArgumentError("binsparse structure field currently unsupported"))
+    structure = get(desc, "structure", "general")
+    bspread_apply_structure(fbr, structure)
+end
+
+function bspread_coo_matrix(f, desc)
+    row = Int.(bspread_data(f, desc, "indices_0")) .+ 1
+    col = Int.(bspread_data(f, desc, "indices_1")) .+ 1
+    val = convert(Vector, bspread_data(f, desc, "values"))
+    shape = Tuple(Int.(desc["shape"]))
+
+    if haskey(f, "fill_value")
+        Vf = bspread_data(f, desc, "fill_value")[1]
+    else
+        Vf = zero(eltype(val))
     end
-    fbr
+
+    fbr = Tensor(sparse(row, col, val, shape...))
+    structure = get(desc, "structure", "general")
+    fbr = bspread_apply_structure(fbr, structure)
+    return fbr
+end
+
+function bspread_apply_structure(fbr, structure::AbstractString)
+    structure == "general" && return fbr
+
+    ndims(fbr) == 2 || throw(
+        ArgumentError("binsparse structure field currently only supported for matrices"),
+    )
+
+    I, J, V = ffindnz(fbr)
+    fill = fill_value(fbr)
+
+    if startswith(structure, "symmetric")
+        keep = I .!= J
+        return bspread_matrix_from_coords(
+            [I; J[keep]],
+            [J; I[keep]],
+            [V; V[keep]],
+            size(fbr),
+            fill,
+        )
+    elseif startswith(structure, "skew_symmetric")
+        keep = I .!= J
+        return bspread_matrix_from_coords(
+            [I; J[keep]],
+            [J; I[keep]],
+            [V; -V[keep]],
+            size(fbr),
+            fill,
+        )
+    elseif startswith(structure, "hermitian")
+        keep = I .!= J
+        return bspread_matrix_from_coords(
+            [I; J[keep]],
+            [J; I[keep]],
+            [V; conj.(V[keep])],
+            size(fbr),
+            fill,
+        )
+    else
+        throw(ArgumentError("unsupported binsparse structure field: $structure"))
+    end
+end
+
+function bspread_matrix_from_coords(I, J, V, shape, fill)
+    fill == zero(eltype(V)) || throw(
+        ArgumentError(
+            "binsparse structured matrices with nonzero fill_value are not currently supported"
+        ),
+    )
+    return Tensor(sparse(I, J, V, shape...))
 end
 
 bspread_level(f, desc, fmt) = bspread_level(f, desc, fmt, Val(Symbol(fmt["level_desc"])))
@@ -404,7 +486,7 @@ function bspwrite_level(f, desc, fmt, lvl::SparseCOOLevel{R}) where {R}
         bspwrite_data(f, desc, "pointers_to_$(N - n)", indices_one_to_zero(lvl.ptr))
     end
     for r in 1:R
-        bspwrite_data(f, desc, "indices_$(N - n + R - r)", indices_one_to_zero(lvl.tbl[r]))
+        bspwrite_data(f, desc, "indices_$(N - n + r - 1)", indices_one_to_zero(lvl.tbl[r]))
     end
     fmt["level"] = OrderedDict()
     bspwrite_level(f, desc, fmt["level"], lvl.lvl)
@@ -415,7 +497,7 @@ function bspread_level(f, desc, fmt, ::Val{:sparse})
     n = level_ndims(typeof(lvl)) + R
     N = length(desc["shape"])
     tbl = (map(1:R) do r
-        indices_zero_to_one(bspread_data(f, desc, "indices_$(N - n + R - r)"))
+        indices_zero_to_one(bspread_data(f, desc, "indices_$(N - n + r - 1)"))
     end...,)
     if N - n > 0
         ptr = bspread_data(f, desc, "pointers_to_$(N - n)")

--- a/src/interface/fileio/fileio.jl
+++ b/src/interface/fileio/fileio.jl
@@ -13,8 +13,10 @@ The following file extensions are supported:
 function fwrite(filename::AbstractString, tns)
     if endswith(filename, ".tns")
         ftnswrite(filename, tns)
-    elseif endswith(filename, ".ttx") || endswith(filename, ".mtx")
+    elseif endswith(filename, ".ttx")
         fttwrite(filename, tns)
+    elseif endswith(filename, ".mtx")
+        fmmwrite(filename, tns)
     elseif endswith(filename, ".bsp.h5") || endswith(filename, ".bsp.hdf5") ||
         endswith(filename, ".bspnpy")
         bspwrite(filename, tns)
@@ -38,14 +40,32 @@ The following file extensions are supported:
 function fread(filename::AbstractString)
     if endswith(filename, ".tns")
         ftnsread(filename)
-    elseif endswith(filename, ".ttx") || endswith(filename, ".mtx")
+    elseif endswith(filename, ".ttx")
         fttread(filename)
+    elseif endswith(filename, ".mtx")
+        fmmread(filename)
     elseif endswith(filename, ".bsp.h5") || endswith(filename, ".bsp.hdf5") ||
         endswith(filename, ".bspnpy")
         bspread(filename)
     else
         error("Unknown file extension for file $filename")
     end
+end
+
+function fmmwrite(args...)
+    throw(
+        FinchExtensionError(
+            "MatrixMarket.jl must be loaded to use write .mtx files",
+        ),
+    )
+end
+
+function fmmread(args...)
+    throw(
+        FinchExtensionError(
+            "MatrixMarket.jl must be loaded to use read .mtx files",
+        ),
+    )
 end
 
 include("binsparse.jl")

--- a/test/suites/fileio_tests.jl
+++ b/test/suites/fileio_tests.jl
@@ -5,6 +5,8 @@
     using JSON
     using SparseArrays
     using Finch: Structure
+    const FINCH_REPO_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+    const FINCH_BIN_DIR = joinpath(FINCH_REPO_ROOT, "bin")
     @testset "h5 binsparse" begin
         let f = mktempdir()
             A = [0.0 1.0 2.0 2.0;
@@ -94,6 +96,18 @@
                 A = fread(fname)
                 A_expected = sparse(Bool[0 1 0; 1 0 1; 0 1 0])
                 @test SparseMatrixCSC(A) == A_expected
+            end
+
+            @testset "binsparse hdf5 group" begin
+                fname = joinpath(f, "grouped.bsp.h5")
+                A = Tensor(sparse([0.0 2.0 0.0; 2.0 0.0 1.0; 0.0 1.0 0.0]))
+                h5open(fname, "w") do io
+                    matrices = create_group(io, "matrices")
+                    Finch.bspwrite(create_group(matrices, "primary"), A)
+                end
+                @test SparseMatrixCSC(h5open(fname, "r") do io
+                    Finch.bspread(io["matrices"]["primary"])
+                end) == SparseMatrixCSC(A)
             end
         end
     end
@@ -198,6 +212,30 @@
             fwrite(joinpath(f, "test.ttx"), Tensor(A_ref))
             str = String(read(joinpath(f, "test.ttx")))
             @test check_output("fileio/Trec4.ttx", str)
+        end
+    end
+
+    @testset "fileio cli" begin
+        let f = mktempdir()
+            mtx2bsp = joinpath(FINCH_BIN_DIR, "mtx2bsp")
+            bsp2mtx = joinpath(FINCH_BIN_DIR, "bsp2mtx")
+            check_equivalence = joinpath(FINCH_BIN_DIR, "check_equivalence")
+
+            source = joinpath(f, "sym.mtx")
+            open(source, "w") do io
+                write(io, "%%MatrixMarket matrix coordinate pattern symmetric\n")
+                write(io, "3 3 2\n")
+                write(io, "2 1\n")
+                write(io, "3 2\n")
+            end
+
+            grouped_bsp = joinpath(f, "sym.bsp.h5:matrices/primary")
+            regenerated = joinpath(f, "sym_out.mtx")
+
+            run(`$mtx2bsp $source $grouped_bsp`)
+            run(`$bsp2mtx $grouped_bsp $regenerated`)
+            run(`$check_equivalence $source $grouped_bsp`)
+            run(`$check_equivalence $grouped_bsp $regenerated`)
         end
     end
 

--- a/test/suites/fileio_tests.jl
+++ b/test/suites/fileio_tests.jl
@@ -2,6 +2,8 @@
     using MatrixMarket
     using Pkg
     using HDF5
+    using JSON
+    using SparseArrays
     using Finch: Structure
     @testset "h5 binsparse" begin
         let f = mktempdir()
@@ -62,6 +64,36 @@
                 fname = joinpath(f, "foo.bsp.h5")
                 bspwrite(fname, B)
                 @test Structure(B) == Structure(bspread(fname))
+            end
+
+            @testset "binsparse iso symmetric_lower" begin
+                fname = joinpath(f, "symmetric_iso.bsp.h5")
+                header = JSON.json(
+                    Dict(
+                        "binsparse" => Dict(
+                            "version" => "0.1",
+                            "format" => "COO",
+                            "shape" => [3, 3],
+                            "number_of_stored_values" => 2,
+                            "structure" => "symmetric_lower",
+                            "data_types" => Dict(
+                                "values" => "iso[bint8]",
+                                "indices_0" => "uint8",
+                                "indices_1" => "uint8",
+                            ),
+                        ),
+                    ),
+                )
+                h5open(fname, "w") do io
+                    attributes(io)["binsparse"] = header
+                    io["values"] = Bool[true]
+                    io["indices_0"] = UInt8[1, 2]
+                    io["indices_1"] = UInt8[0, 1]
+                end
+
+                A = fread(fname)
+                A_expected = sparse(Bool[0 1 0; 1 0 1; 0 1 0])
+                @test SparseMatrixCSC(A) == A_expected
             end
         end
     end
@@ -166,6 +198,26 @@
             fwrite(joinpath(f, "test.ttx"), Tensor(A_ref))
             str = String(read(joinpath(f, "test.ttx")))
             @test check_output("fileio/Trec4.ttx", str)
+        end
+    end
+
+    @testset "matrix market symmetric" begin
+        let f = mktempdir()
+            fname = joinpath(f, "sym.mtx")
+            open(fname, "w") do io
+                write(io, "%%MatrixMarket matrix coordinate pattern symmetric\n")
+                write(io, "3 3 2\n")
+                write(io, "2 1\n")
+                write(io, "3 2\n")
+            end
+
+            A = fread(fname)
+            A_expected = sparse(Bool[0 1 0; 1 0 1; 0 1 0])
+            @test SparseMatrixCSC(A) == A_expected
+
+            out = joinpath(f, "sym_out.mtx")
+            fwrite(out, Tensor(A_expected))
+            @test occursin("symmetric", lowercase(first(split(read(out, String), '\n'))))
         end
     end
 


### PR DESCRIPTION
## Summary

This PR makes a few updates and modifications to Finch.jl to support the Binsparse files and Matrix Market files used by the (WIP) [Binsparse testing framework](https://github.com/BenBrock/binsparse-tests).

This consists primarily of 1) routing `.mtx` files to `MatrixMarket.jl` instead of TensorMarket, since TensorMarket fails on Matrix Market files; 2) Adding support for `iso[...]` scalar values; and 3) extending Finch's Binsparse reader to properly handled structured matrices (symmetric, etc.).

**The rest of this PR summary is generated by Codex.  Most of the code changes in this PR are AI-generated and need review (thus it's a draft PR).**

The main changes are:

- add native .mtx support through MatrixMarket.jl instead of routing .mtx files through the TensorMarket path
- add a MatrixMarketExt extension that reads Matrix Market files into Finch tensors and writes Finch tensors back to Matrix Market
- extend binsparse reading to support iso[...] value encodings
- extend binsparse reading to honor matrix structure metadata for symmetric, skew_symmetric, and hermitian matrices
- add a COO-specific binsparse matrix read path for 2D matrix fixtures
- fix COO index ordering in binsparse read/write so generated files line up with the current fixture layout

## Motivation

The current Finch fileio path had a few gaps that showed up immediately when running the new binsparse parser test framework:

- symmetric Matrix Market files were not handled correctly through the normal .mtx path
- binsparse fixtures using iso[...] value metadata could not be read
- binsparse fixtures with structure metadata such as symmetric_lower could not be reconstructed correctly

This branch closes those gaps so Finch can participate in the same roundtrip fixture tests as the other parser implementations.

## Tests

Added coverage for:

- reading binsparse HDF5 fixtures with iso[bint8] values and symmetric_lower structure
- reading and writing symmetric Matrix Market files

Validated with:

- Finch fileio test suite: 109 passed
- binsparse interoperability harness against the local Finch adapter: 4 passed