### PR TITLE
Implement LinearAlgebra.adjoint and transpose for tensors (#767)

### DIFF
--- a/src/interface/eager.jl
+++ b/src/interface/eager.jl
@@ -172,6 +172,28 @@ function LinearAlgebra.norm(arr::AbstractTensorOrBroadcast, p::Real=2)
 end
 
 """
+    transpose(arr::AbstractTensor)
+
+Transpose a 2-dimensional tensor, returning a new tensor (equivalent to
+`permutedims`).
+"""
+function LinearAlgebra.transpose(arr::AbstractTensor)
+    @assert ndims(arr) == 2 "transpose is only defined for 2-dimensional tensors"
+    permutedims(arr)
+end
+
+"""
+    adjoint(arr::AbstractTensor)
+
+Form the conjugate transpose of a 2-dimensional tensor, returning a new tensor.
+For real element types this is equivalent to `transpose`.
+"""
+function LinearAlgebra.adjoint(arr::AbstractTensor)
+    @assert ndims(arr) == 2 "adjoint is only defined for 2-dimensional tensors"
+    compute(adjoint(lazy(arr)))
+end
+
+"""
     expanddims(arr::AbstractTensor; dims=:)
 
 Expand the dimensions of an array by inserting a new singleton axis or axes that

--- a/src/interface/lazy.jl
+++ b/src/interface/lazy.jl
@@ -352,6 +352,28 @@ function Base.permutedims(arg::LazyTensor{Vf,Tv,N}, perm) where {Vf,Tv,N}
 end
 Base.permutedims(arr::SwizzleArray, perm) = swizzle(arr, perm...)
 
+"""
+    transpose(arr::LazyTensor)
+
+Lazily transpose a 2-dimensional `LazyTensor` (equivalent to `permutedims`).
+"""
+LinearAlgebra.transpose(arr::LazyTensor{Vf,Tv,2}) where {Vf,Tv} = permutedims(arr)
+
+"""
+    adjoint(arr::LazyTensor)
+
+Lazily form the conjugate transpose of a 2-dimensional `LazyTensor`. For real
+element types this is equivalent to `transpose`; for complex element types the
+elements are conjugated.
+"""
+function LinearAlgebra.adjoint(arr::LazyTensor{Vf,Tv,2}) where {Vf,Tv}
+    if Tv <: Real
+        return permutedims(arr)
+    else
+        return map(conj, permutedims(arr))
+    end
+end
+
 function Base.:+(
     x::LazyTensor,
     y::Union{LazyTensor,AbstractTensor,Base.AbstractArrayOrBroadcasted,Number},

--- a/test/suites/issue_tests.jl
+++ b/test/suites/issue_tests.jl
@@ -1,6 +1,7 @@
 @testitem "issues" setup = [CheckOutput] begin
     using SparseArrays
     using Finch: Structure
+    using LinearAlgebra
 
     #https://github.com/finch-tensor/Finch.jl/issues/603
     let
@@ -1245,4 +1246,34 @@
         A = Tensor(COOFormat(2, 0.0), fsprand(4, 4, 0.9))
         @test ffindnz!(A)[1] === A.lvl.tbl[1]
     end
+
+    #https://github.com/finch-tensor/Finch.jl/issues/767
+    let
+        # real matrix: transpose == adjoint == permutedims
+        A = [1.0 2.0 3.0; 4.0 5.0 6.0]
+        A_tns = Tensor(Dense(Dense(Element(0.0))), A)
+        @test transpose(A_tns) == permutedims(A)
+        @test adjoint(A_tns) == permutedims(A)
+        @test compute(transpose(lazy(A_tns))) == permutedims(A)
+        @test compute(adjoint(lazy(A_tns))) == permutedims(A)
+
+        # complex matrix: adjoint conjugates, transpose does not
+        C = [1.0+2.0im 3.0-1.0im; 0.0+1.0im 2.0+0.0im]
+        C_tns = Tensor(Dense(Dense(Element(0.0im))), C)
+        @test transpose(C_tns) == permutedims(C)
+        @test adjoint(C_tns) == permutedims(conj.(C))
+        @test compute(transpose(lazy(C_tns))) == permutedims(C)
+        @test compute(adjoint(lazy(C_tns))) == permutedims(conj.(C))
+
+        # sparse input, real
+        S = fsprand(6, 8, 0.3)
+        S_tns = Tensor(Dense(SparseList(Element(0.0))), S)
+        @test adjoint(S_tns) == permutedims(Array(S))
+        @test transpose(S_tns) == permutedims(Array(S))
+
+        # exact reproducer from the issue: adjoint on a COO Bool tensor
+        R = fsprand(Bool, 100, 100, 0.01)
+        @test adjoint(R) == permutedims(Array(R))
+    end
+
 end


### PR DESCRIPTION
Implements `LinearAlgebra.adjoint` and `LinearAlgebra.transpose` for Finch tensors, closing #767.

Previously neither had methods for `Tensor`/`LazyTensor`, so e.g. `adjoint(fsprand(Bool, 100, 100, 0.01))` threw a `MethodError`.

**Changes.** In the eager layer (`src/interface/eager.jl`), `transpose(::AbstractTensor)` and `adjoint(::AbstractTensor)` are defined for 2-D tensors, delegating through `permutedims` and `compute(adjoint(lazy(arr)))`, mirroring the existing `norm` methods. In the lazy layer (`src/interface/lazy.jl`), `transpose`/`adjoint` are defined for `LazyTensor{Vf,Tv,2}`, where `adjoint` returns `permutedims` for real element types and `map(conj, permutedims(arr))` for complex ones. Tests in `test/suites/issue_tests.jl` cover real and complex, dense and sparse, and both eager and lazy paths, plus the exact reproducer from the issue.

**Open questions.** (1) Scope is limited to 2-D matrices, matching `permutedims(::AbstractTensor)`, would you like vector (N=1) support as well? (2) It returns a materialized/lazy Finch tensor rather than a `Base.Adjoint`/`Transpose` wrapper, to stay consistent with `permutedims`/`norm`; happy to switch to wrapper semantics if you prefer.

Local run of `./test/runtests.jl --include issues` passes (158 pass, 0 fail).